### PR TITLE
Bump vuepress-theme-succinct version to fix table style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11517,17 +11517,17 @@
          "dev": true
       },
       "vuepress-theme-succinct": {
-         "version": "1.5.2",
-         "resolved": "https://registry.npmjs.org/vuepress-theme-succinct/-/vuepress-theme-succinct-1.5.2.tgz",
-         "integrity": "sha512-EECeZq09VYYcapYtD2/MBVHhg9qkV1IfdPU0Tr3Rn/MRe2rI4K0aAu8TBCMme9GD6eDM1MX1GRNAWlRYMy7OWg==",
+         "version": "1.5.3",
+         "resolved": "https://registry.npmjs.org/vuepress-theme-succinct/-/vuepress-theme-succinct-1.5.3.tgz",
+         "integrity": "sha512-FampNDN6/yah71v2kid8tn4Mb77tOZ+3fUT7EfDzUflw+o5kBatGBIZdRWxvYOqvLCt9k/hjSWun+n0/gPd43g==",
          "dev": true,
          "requires": {
             "@vuepress/plugin-active-header-links": "^1.5.2",
             "@vuepress/plugin-nprogress": "^1.5.2",
             "@vuepress/plugin-search": "^1.5.2",
             "docsearch.js": "^2.5.2",
-            "lodash": "^4.17.15",
-            "stylus": "^0.54.5",
+            "lodash": "^4.17.19",
+            "stylus": "^0.54.8",
             "stylus-loader": "^3.0.2",
             "vuepress-plugin-container": "^2.1.4",
             "vuepress-plugin-smooth-scroll": "^0.0.9"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "vuepress-plugin-zooming": "^1.1.7",
       "vuepress-theme-book": "0.0.3",
       "vuepress-theme-dark-new": "^0.1.2",
-      "vuepress-theme-succinct": "^1.5.2",
+      "vuepress-theme-succinct": "^1.5.3",
       "vuepress-theme-yuu": "^2.3.0"
    },
    "homepage": "https://dortania.github.io/OpenCore-Install-Guide/"


### PR DESCRIPTION
Table content on [this page](https://dortania.github.io/OpenCore-Install-Guide/terminology.html) is very crowded, and the code backgrounds are overlapping. I recently opened a pull request on the original theme repo to fix the line height issue with tables. A simple version bump should fix this.