### PR TITLE
[Big Sur] Add AirportBrcmInjector Plugin Known Issue

### DIFF
--- a/extras/big-sur/README.md
+++ b/extras/big-sur/README.md
@@ -107,6 +107,7 @@ With Big Sur, quite a bit broke. Mainly the following:
 * AirportBrcmFixup
   * Forcing a specific driver to load with `brcmfx-driver=` may help
   * BCM94352Z users for example may need `brcmfx-driver=2` in boot-args to resolve this, other chipsets will need other variables.
+  * Deleting AirPortBrcm4360_Injector.kext from AirportBrcmInjector.kext/Content/Plugins may help
 * Intel HEDT hackintoshes failing to boot
   * This is due to Asus and many other OEMs excluding certain regions from your RTC device, to resolve this we can create a new RTC device with the proper regions.
   * OpenCorePkg includes a sample SSDT that goes in-depth: [SSDT-RTC0-RANGE.dsl](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-RTC0-RANGE.dsl)

--- a/extras/big-sur/README.md
+++ b/extras/big-sur/README.md
@@ -107,7 +107,7 @@ With Big Sur, quite a bit broke. Mainly the following:
 * AirportBrcmFixup
   * Forcing a specific driver to load with `brcmfx-driver=` may help
   * BCM94352Z users for example may need `brcmfx-driver=2` in boot-args to resolve this, other chipsets will need other variables.
-  * Removing/blocking AirPortBrcm4360_Injector.kext may help. More information [from the repo](https://github.com/acidanthera/AirportBrcmFixup/blob/master/README.md#please-pay-attention)
+  * Setting MaxKernel to 19.9.9 for AirPortBrcm4360_Injector.kext may help. More information [from the repo](https://github.com/acidanthera/AirportBrcmFixup/blob/master/README.md#please-pay-attention)
 * Intel HEDT hackintoshes failing to boot
   * This is due to Asus and many other OEMs excluding certain regions from your RTC device, to resolve this we can create a new RTC device with the proper regions.
   * OpenCorePkg includes a sample SSDT that goes in-depth: [SSDT-RTC0-RANGE.dsl](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-RTC0-RANGE.dsl)

--- a/extras/big-sur/README.md
+++ b/extras/big-sur/README.md
@@ -107,7 +107,7 @@ With Big Sur, quite a bit broke. Mainly the following:
 * AirportBrcmFixup
   * Forcing a specific driver to load with `brcmfx-driver=` may help
   * BCM94352Z users for example may need `brcmfx-driver=2` in boot-args to resolve this, other chipsets will need other variables.
-  * Deleting AirPortBrcm4360_Injector.kext from AirportBrcmInjector.kext/Content/Plugins may help
+  * Removing/blocking AirPortBrcm4360_Injector.kext may help. More information [from the repo](https://github.com/acidanthera/AirportBrcmFixup/blob/master/README.md#please-pay-attention)
 * Intel HEDT hackintoshes failing to boot
   * This is due to Asus and many other OEMs excluding certain regions from your RTC device, to resolve this we can create a new RTC device with the proper regions.
   * OpenCorePkg includes a sample SSDT that goes in-depth: [SSDT-RTC0-RANGE.dsl](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-RTC0-RANGE.dsl)


### PR DESCRIPTION
Removing the non-nic plugin kext solves wifi hardware detection on 94352Z/HMB