### PR TITLE
Update spoof.md

### DIFF
--- a/extras/spoof.md
+++ b/extras/spoof.md
@@ -115,13 +115,13 @@ Many users only have two GPUs. Nvidia and the Intel HD/UHD IGPU. Since Nvidia no
 The rendered game or application will have its buffer copied to the IGPU. Which is then displayed to you. This does come with a few downsides:
 
 * GSync will no longer work.
-* Nvidia settings can no longer be opened.
+* Nvidia settings can no longer be opened. This requires the display to be connected to the GPU
 * Decreased frame rate.
 * Increased input latency.
 * Refresh rate cap.
 
-If your motherboard only has an HDMI connector for the IGPU, the maximum refresh rate for spec 2.1 is [120Hz](https://www.hdmi.org/spec21Sub/EightK60_FourK120). This assumes your board, cable and monitor are of the same spec. This means your 144Hz monitor is only seeing a maximum of 120Hz as determined by the hardware. This limitation *does not* apply if your board has a DP connector for the IGPU.
+If your motherboard only has an HDMI connector for the IGPU, the maximum refresh rate for spec 2.1 is [120Hz](https://www.hdmi.org/spec21Sub/EightK60_FourK120). This assumes your board and monitor are of the same spec. This means your 144Hz monitor is only seeing a maximum of 120Hz as determined by the hardware. This limitation *does not* apply if your board has a DP connector for the IGPU.
 
-If you have more than two GPUs (AMD, Nvidia and Intel), this setting is limited. A monitor connected to the AMD GPU means Windows will only allow you to select the AMD GPU or the Intel IGPU. The Nvidia GPU will not show.
+If you have more than two GPUs (AMD, Nvidia and Intel), this setting is limited. A monitor connected to the AMD GPU means Windows will only allow you to select the AMD GPU or the Intel IGPU. The Nvidia GPU will not show. In a future version of Windows, this [limitation is removed](https://pureinfotech.com/windows-10-21h1-new-features/#:~:text=Graphics%20settings).
 
-Note: GSync and NV Settings requires the display to be connected to the GPU. As a recommendation, if you use both operating systems equally your best option is an HDMI or DP switch.
+As a recommendation, if you use both operating systems equally and prefer no downsides, your best option is an HDMI or DP switch.


### PR DESCRIPTION
- Cable spec is actually irrelevant/not real. The only requirement is must be labeled "High Speed" on the packaging to support the high bandwidth requirement of later HDMI versions. If labeled High Speed, it will work for all versions of the HDMI spec.

- A future build of Windows coming next year lifts the 2 GPU cap in settings. Allowing users to select the IGPU, AMD or Nvidia GPU in triple GPU systems. In some cases, a switch is still recommended. But the good news is for those who don't mind the downsides listed, this is good news.