### PR TITLE
Update haswell.md

### DIFF
--- a/config.plist/haswell.md
+++ b/config.plist/haswell.md
@@ -295,7 +295,7 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | AllowNvramReset | YES | |
 | AllowSetDefault | YES | |
 | ScanPolicy | 0 | |
-| SecureBootModel | Default |  This is a word and is case-sensitive, set to `Disabled` if you do not want secure boot(ie. you require Nvidia's Web Drivers) |
+| SecureBootModel | Disabled |  This is a word and is case-sensitive, set to `Disabled` if you do not want secure boot(ie. you require Nvidia's Web Drivers) You will regret it if you don't set it to Disabled |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 :::
 


### PR DESCRIPTION
Stuck on boot after update to OC 0.6.1

When trying to boot from flash or internal sata ssd(in my case) with updated EFI folder I'm getting this error messages:
```
OCSB: No suitable signature - Security Violation
OCB: Apple Secure Boot prohibits this boot entry, enforcing!
OCB: LoadImage failed - Security Violation
```

I have exact same issue with OC 0.6.1 and macOS 10.15.4: [https://www.reddit.com/r/hackintosh/comments/iocl5g/stuck_on_boot_after_update_to_oc_061/](https://www.reddit.com/r/hackintosh/comments/iocl5g/stuck_on_boot_after_update_to_oc_061/)

Solution: **Since 0.6.1 is AppleSecureBoot implemented. Add in your config.plist into Misc > Security string key named SecureBootModel with value Disabled. (Page 45 of official manual)**