### PR TITLE
HfsPlusLegacy.efi for ivy-bridge i3 or celeron

### DIFF
--- a/dictionary/dictionary.txt
+++ b/dictionary/dictionary.txt
@@ -399,9 +399,11 @@ Haswell
 Haswell-E
 Hfs
 HfsPlus
+HfsPlus's
 HfsPlus32
 HfsPlusLegacy
 HiDPI
+HiiDatabase
 HoRNDIS
 Hx6x
 I211
@@ -953,6 +955,7 @@ i219
 i225
 i225-V
 i225LM
+i3
 i3-3110M
 i7
 i7-10700K

--- a/ktext.md
+++ b/ktext.md
@@ -25,9 +25,8 @@ Firmware drivers are drivers used by OpenCore in the UEFI environment. They're m
 For the majority of systems, you'll only need 2 `.efi` drivers to get up and running:
 
 * [HfsPlus.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlus.efi)
-  * Needed for seeing HFS volumes(ie. macOS Installers and Recovery partitions/images). 
+  * Needed for seeing HFS volumes(ie. macOS Installers and Recovery partitions/images). **Do not mix other HFS drivers**
   * if your CPU don't support Intel® AES New Instructions(third generation i3 and below), try to use [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi), oherwise, it will always restart or stuck on a black screen.
-  * **Do not mix other HFS drivers**
 * [OpenRuntime.efi](https://github.com/acidanthera/OpenCorePkg/releases)
   * Replacement for [AptioMemoryFix.efi](https://github.com/acidanthera/AptioFixPkg), used as an extension for OpenCore to help with patching boot.efi for NVRAM fixes and better memory management.
 

--- a/ktext.md
+++ b/ktext.md
@@ -39,11 +39,11 @@ In addition to the above, if your hardware doesn't support UEFI(2011 and older e
 * [OpenUsbKbDxe.efi](https://github.com/acidanthera/OpenCorePkg/releases)
   * Used for OpenCore picker on **legacy systems running DuetPkg**, [not recommended and even harmful on UEFI(Ivy Bridge and newer)](https://applelife.ru/threads/opencore-obsuzhdenie-i-ustanovka.2944066/page-176#post-856653)
 * [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi)
-  * Legacy variant of HfsPlus, used for systems that lack RDRAND instruction support. This is generally seen on Ivy Bridge(i3 or Celeron) and older
+  * Legacy variant of HfsPlus, used for systems that lack RDRAND instruction support. This is generally seen on Sandy Bridge and older(as well as low end Ivy Bridge(i3 and Celerons))
   * Don't mix this with HfsPlus.efi, choose one or the other depending on your hardware
 * [PartitionDxe](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/PartitionDxe.efi)
   * Required to boot recovery on OS X 10.7 through 10.9
-  * For Sandy Bridge and older, you'll want to use [PartitionDxeLegacy](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/PartitionDxeLegacy.efi) due to missing RDRAND instruction.
+  * For Sandy Bridge and older(as well as low end Ivy Bridge(i3 and Celerons)), you'll want to use [PartitionDxeLegacy](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/PartitionDxeLegacy.efi) due to missing RDRAND instruction.
   * Not required for OS X 10.10, Yosemite and newer
 
 These files will go in your Drivers folder in your EFI

--- a/ktext.md
+++ b/ktext.md
@@ -25,7 +25,9 @@ Firmware drivers are drivers used by OpenCore in the UEFI environment. They're m
 For the majority of systems, you'll only need 2 `.efi` drivers to get up and running:
 
 * [HfsPlus.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlus.efi)
-  * Needed for seeing HFS volumes(ie. macOS Installers and Recovery partitions/images). **Do not mix other HFS drivers**
+  * Needed for seeing HFS volumes(ie. macOS Installers and Recovery partitions/images). 
+  * if your CPU don't support Intel® AES New Instructions(third generation i3 and below), try to use [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi), oherwise, it will always restart or stuck on a black screen.
+  * **Do not mix other HFS drivers**
 * [OpenRuntime.efi](https://github.com/acidanthera/OpenCorePkg/releases)
   * Replacement for [AptioMemoryFix.efi](https://github.com/acidanthera/AptioFixPkg), used as an extension for OpenCore to help with patching boot.efi for NVRAM fixes and better memory management.
 
@@ -38,7 +40,7 @@ In addition to the above, if your hardware doesn't support UEFI(2011 and older e
 * [OpenUsbKbDxe.efi](https://github.com/acidanthera/OpenCorePkg/releases)
   * Used for OpenCore picker on **legacy systems running DuetPkg**, [not recommended and even harmful on UEFI(Ivy Bridge and newer)](https://applelife.ru/threads/opencore-obsuzhdenie-i-ustanovka.2944066/page-176#post-856653)
 * [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi)
-  * Legacy variant of HfsPlus, used for systems that lack RDRAND instruction support. This is generally seen on Sandy Bridge and older
+  * Legacy variant of HfsPlus, used for systems that lack RDRAND instruction support. This is generally seen on Ivy Bridge(i3 or Celeron) and older
   * Don't mix this with HfsPlus.efi, choose one or the other depending on your hardware
 * [PartitionDxe](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/PartitionDxe.efi)
   * Required to boot recovery on OS X 10.7 through 10.9

--- a/ktext.md
+++ b/ktext.md
@@ -26,7 +26,7 @@ For the majority of systems, you'll only need 2 `.efi` drivers to get up and run
 
 * [HfsPlus.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlus.efi)
   * Needed for seeing HFS volumes(ie. macOS Installers and Recovery partitions/images). **Do not mix other HFS drivers**
-  * if your CPU don't support Intel® AES New Instructions(third generation i3 and below), try to use [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi), oherwise, it will always restart or stuck on a black screen.
+  * For Sandy Bridge and older(as well as low end Ivy Bridge(i3 and Celerons), see the legacy section below
 * [OpenRuntime.efi](https://github.com/acidanthera/OpenCorePkg/releases)
   * Replacement for [AptioMemoryFix.efi](https://github.com/acidanthera/AptioFixPkg), used as an extension for OpenCore to help with patching boot.efi for NVRAM fixes and better memory management.
 

--- a/troubleshooting/extended/opencore-issues.md
+++ b/troubleshooting/extended/opencore-issues.md
@@ -4,6 +4,7 @@
 
 Issues surrounding from initial booting the USB itself to right before you choose to boot the macOS installer
 
+* [Stuck on a black screen before picker or always restart](#stuck-on-a-black-screen-before-picker)
 * [Stuck on `no vault provided!`](#stuck-on-no-vault-provided)
 * [Stuck on `OC: Invalid Vault mode`](#stuck-on-oc-invalid-vault-mode)
 * [Stuck on `OCB: OcScanForBootEntries failure - Not Found`](#stuck-on-ocb-ocscanforbootentries-failure-not-found)
@@ -16,6 +17,9 @@ Issues surrounding from initial booting the USB itself to right before you choos
 * [SSDTs not being added](#ssdts-not-being-added)
 * [Booting OpenCore reboots to BIOS](#booting-opencore-reboots-to-bios)
 * [OCABC: Incompatible OpenRuntime r4, require r10](#ocabc-incompatible-openruntime-r4-require-r10)
+
+## Stuck on a black screen before picker
+Try to use [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi) instead of [HfsPlus.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlus.efi) (Ivy bridge i3 and older)
 
 ## Stuck on `no vault provided!`
 

--- a/troubleshooting/extended/opencore-issues.md
+++ b/troubleshooting/extended/opencore-issues.md
@@ -19,7 +19,28 @@ Issues surrounding from initial booting the USB itself to right before you choos
 * [OCABC: Incompatible OpenRuntime r4, require r10](#ocabc-incompatible-openruntime-r4-require-r10)
 
 ## Stuck on a black screen before picker
-Try to use [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi) instead of [HfsPlus.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlus.efi) (Ivy bridge i3 and older)
+
+This is likely some error either on your firmware or OpenCore, specifically it's having troubles loading all the drivers and presenting the menu. The best way to diagnose it is via [OpenCore's DEBUG Build](./../debug.md) and checking the logs whether OpenCore actually loaded, and if so what is it getting stuck on.
+
+**Situations where OpenCore did not load**:
+
+* If there are no logs present even after setting up the DEBUG version of OpenCore with Target set to 67, there's likely an issue either with:
+  * Incorrect USB Folder Structure
+    * See [Booting OpenCore reboots to BIOS](#booting-opencore-reboots-to-bios) for more info
+  * Firmware does not support UEFI
+    * You'll need to setup DuetPkg, this is covered in both the [macOS](../../installer-guide/mac-install.md) and [Windows](../../installer-guide/winblows-install.md) install pages
+
+**Situations where OpenCore did load**:
+
+* Check the last line printed in your logs, there will likely be either a .efi driver that's been loaded or some form of ASSERT
+  * For ASSERT's, you'll want to actually inform the developers about this issue here: [Acidanthera's Bugtracker](https://github.com/acidanthera/bugtracker)
+  * For .efi drivers getting stuck, check over the following:
+    * **HfsPlus.efi load issues:**
+      * Try using [HfsPlusLegacy.efi](https://github.com/acidanthera/OcBinaryData/blob/master/Drivers/HfsPlusLegacy.efi) instead
+      * This is recommended for CPUs that do not support RDRAND, mainly relevant for 3rd gen Ivy bridge i3 and older
+      * [VBoxHfs.efi](https://github.com/acidanthera/AppleSupportPkg/releases/tag/2.1.7) is another option however is much slower than HfsPlus's version
+    * **HiiDatabase.efi load issues:**
+      * Likely your firmware already supports HiiDatabase, so the driver is conflicting. Simply remove the driver as you don't need it.
 
 ## Stuck on `no vault provided!`
 


### PR DESCRIPTION
if use old saying, Ivy 's i3 and celeron will use HFSPlus.efi, finally get a black screen before picker