### PR TITLE
Add Whiskey Lake, Comet Lake to sidebar

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -155,8 +155,8 @@ module.exports = {
 					['/config-laptop.plist/broadwell', 'Broadwell'],
                     ['/config-laptop.plist/skylake', 'Skylake'],
                     ['/config-laptop.plist/kaby-lake', 'Kaby Lake'],
-                    ['/config-laptop.plist/coffee-lake', 'Coffee Lake'],
-					['/config-laptop.plist/coffee-lake-plus', 'Coffee Lake Plus'],
+                    ['/config-laptop.plist/coffee-lake', 'Coffee Lake and Whiskey Lake'],
+					['/config-laptop.plist/coffee-lake-plus', 'Coffee Lake Plus and Comet Lake'],
                     ['/config-laptop.plist/icelake', 'Ice Lake'],
                 ]
             },

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -1,9 +1,10 @@
-# Laptop Coffee Lake
+# Laptop Coffee Lake and Whiskey Lake
 
 | Support | Version |
 | :--- | :--- |
 | Supported OpenCore version | 0.6.2 |
-| Initial macOS Support | macOS 10.13, High Sierra |
+| Initial macOS Support ([Coffee Lake](https://en.wikipedia.org/wiki/Coffee_Lake)) | macOS 10.13, High Sierra |
+| Initial macOS Support ([Whiskey Lake](https://en.wikipedia.org/wiki/Whiskey_Lake_(microarchitecture))) | macOS 10.14.1, Mojave |
 
 ## Starting Point
 


### PR DESCRIPTION
This adds Whiskey Lake, Comet Lake to the sidebar. 

They were already mentioned in the [config.plist/README.md](config.plist/README.md) but not in the sidebar or page title in case of Whiskey Lake, which was confusing.

If we are missing any other generations, I can add them as well in this PR.