### PR TITLE
Notify users with RealtekRTL8111 issue

### DIFF
--- a/ktext.md
+++ b/ktext.md
@@ -157,7 +157,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
 * [RealtekRTL8111](https://github.com/Mieze/RTL8111_driver_for_OS_X/releases)
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8-11(2.2.0), 10.12-13(v2.2.2), 10.14+(2.3.0)
-  * **NOTE: Sometimes Realtek's Gigabit Ethernet can still not work if you have RealtekRTL8111 2.3.0 and OpenCore 0.6.2. If you see this issue, try reverting to version 2.2.2 or downgrade OpenCore to version 0.6.1**
+  * **NOTE: Sometimes Realtek's Gigabit Ethernet may not work correctly if you have RealtekRTL8111 v2.3.0. If you see this issue, try reverting to version 2.2.2**
 * [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer

--- a/ktext.md
+++ b/ktext.md
@@ -157,6 +157,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
 * [RealtekRTL8111](https://github.com/Mieze/RTL8111_driver_for_OS_X/releases)
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8-11(2.2.0), 10.12-13(v2.2.2), 10.14+(2.3.0)
+  * **NOTE: Sometimes Realtek's Gigabit Ethernet can still not work if you have RealtekRTL8111 2.3.0 and OpenCore 0.6.2. If you see this issue, try reverting to version 2.2.2 or downgrade OpenCore to version 0.6.1**
 * [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer


### PR DESCRIPTION
RealtekRTL8111 2.3.0 has seen stability issues with OpenCore 0.6.2. A workaround while waiting for Mieze to fix this issue is to downgrade to RealtekRTL8111 to version 2.2.2 or downgrade OpenCore to version 0.6.1 (an issue has been opened about this but it does not look like Mieze is going to fix this issue any time soon)