### PR TITLE
add sanity check link to kaby lake

### DIFF
--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -694,6 +694,7 @@ For those having booting issues, please make sure to read the [Troubleshooting s
 **Sanity check**:
 
 So thanks to the efforts of Ramus, we also have an amazing tool to help verify your config for those who may have missed something:
+- [Sanity Check](https://opencore.slowgeek.com/)
 
 ### Config reminders
 

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -694,7 +694,8 @@ For those having booting issues, please make sure to read the [Troubleshooting s
 **Sanity check**:
 
 So thanks to the efforts of Ramus, we also have an amazing tool to help verify your config for those who may have missed something:
-- [Sanity Check](https://opencore.slowgeek.com/)
+
+* [**Sanity Checker**](https://opencore.slowgeek.com)
 
 ### Config reminders
 


### PR DESCRIPTION
it seems there is a space for the link like in other docs but it doesn't seem to actually be present
if I missed some reason for the omission let me know