### PR TITLE
Updated Kernel Issues

### DIFF
--- a/troubleshooting/extended/kernel-issues.md
+++ b/troubleshooting/extended/kernel-issues.md
@@ -73,7 +73,10 @@ The main culprits to watch for in the Booter section are:
       * EnableWriteUnprotector -> True
       * RebuildAppleMemoryMap -> False
       * SyncRuntimePermissions -> False
-    * Note: Some laptops(ex. Dell Inspiron 5370) even with MATs support will halt on boot up, in these cases you'll be required to boot with the old firmware combo(ie. With EnableWriteUnprotector)
+    * Note: Some laptops(ex. Dell Inspiron 5370) even with MATs support will halt on boot up, in these cases you'll have two options:
+    
+       * boot with the old firmware combo(ie. With EnableWriteUnprotector and disable `RebuildAppleMemoryMap` + `SyncRuntimePermissions`)
+       * enable `DevirtualiseMmio` and follow [MmioWhitelist guide](https://dortania.github.io/OpenCore-Install-Guide/extras/kaslr-fix.html#using-devirtualisemmio)
 
 Regarding MATs support, firmwares built against EDK 2018 will support this and many OEMs have even added support all the way back to Skylake laptops. Issue is it's not always obvious if an OEM has updated the firmware, you can check the OpenCore logs whether yours supports it([See here how to get a log](../debug.html)):
 


### PR DESCRIPTION
There are some laptops, like my Dell Inspiron 5370, which have a faulty MMIO. 

The only way to boot them with `SyncRuntimePermissions` + `RebuildAppleMemoryMap` is whitelisting one/more MMIO regions. For more infos check out my [repo](https://github.com/dreamwhite/dell-inspiron-5370-hackintosh/)