### PR TITLE
Change link for AMD CPU list and add info on AirportBrcmFixup for Big Sur

### DIFF
--- a/config.plist/README.md
+++ b/config.plist/README.md
@@ -99,7 +99,7 @@ This section includes both enthusiast and server based hardware.
 
 | Code Name | Series | Release |
 | :--- | :--- | :--- |
-| [Bulldozer/Jaguar](../AMD/fx.md) | [It's weird](https://en.wikipedia.org/wiki/Advanced_Micro_Devices) | [AMD was really bad with naming back then](https://en.wikipedia.org/wiki/Advanced_Micro_Devices) |
+| [Bulldozer/Jaguar](../AMD/fx.md) | [It's weird](https://en.wikipedia.org/wiki/List_of_AMD_processors#Bulldozer_architecture;_Bulldozer,_Piledriver,_Steamroller,_Excavator_(2011%E2%80%932017)) | [AMD was really bad with naming back then](https://en.wikipedia.org/wiki/List_of_AMD_processors#Bulldozer_architecture;_Bulldozer,_Piledriver,_Steamroller,_Excavator_(2011%E2%80%932017)) |
 | [Zen](../AMD/zen.md) | 1XXX, 2XXX, 3XXX, 5XXX | 2017-2020 era |
 
 * Note: ~~Threadripper 3rd gen(39XX) are not supported, 1st and 2nd gen however are supported~~

--- a/ktext.md
+++ b/ktext.md
@@ -287,6 +287,7 @@ To enable AirportItlwm support with OpenCore, you'll need to either:
 * [AirportBrcmFixup](https://github.com/acidanthera/AirportBrcmFixup/releases)
   * Used for patching non-Apple/non-Fenvi Broadcom cards, **will not work on Intel, Killer, Realtek, etc**
   * Requires OS X 10.10 or newer
+  * For Big Sur see [Big Sur Known Issues](./extras/big-sur#known-issues) for extra steps regarding AirPortBrcm4360 drivers.
 * [BrcmPatchRAM](https://github.com/acidanthera/BrcmPatchRAM/releases)
   * Used for uploading firmware on Broadcom Bluetooth chipset, required for all non-Apple/non-Fenvi Airport cards.
   * To be paired with BrcmFirmwareData.kext


### PR DESCRIPTION
- Changed link to AMD series CPUs to [wikipedia's list](https://en.wikipedia.org/wiki/List_of_AMD_processors#Bulldozer_architecture;_Bulldozer,_Piledriver,_Steamroller,_Excavator_(2011%E2%80%932017) instead of  just linking the AMD wiki page

- Added link to known issues regarding AirportBrcmFixup for Big Sur for further steps required. (This would save time in troubleshooting why wifi isn't working)