### PR TITLE
Updated winblows-install.md

### DIFF
--- a/installer-guide/winblows-install.md
+++ b/installer-guide/winblows-install.md
@@ -2,6 +2,8 @@
 
 * Supported version: 0.6.4
 
+## Please note that the following procedure may take up 2 minutes to boot macOS Recovery. Be patient
+
 While you don't need a fresh install of macOS to use OpenCore, some users prefer having a fresh slate with their boot manager upgrades.
 
 To start you'll need the following:


### PR DESCRIPTION
I tried with different PCs booting macOS recovery and after booting OpenCore (which takes up to 10 seconds usually to show the boot-picker) and selecting "USB" drive, which contains BaseSystem.dmg, the recovery started booting after 1 minute circa. I don't know if this can be considered a bug-report but just wanted to clarify that.

# Credits

@Emanuele-1998 for testing with different PCs