### PR TITLE
iMac4,2 incompatibility with Big Sur (zen)

### DIFF
--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -543,7 +543,7 @@ For this example, we'll choose the iMacPro1,1 SMBIOS but some SMBIOS play with c
 * iMacPro1,1: AMD RX Polaris and newer
 * MacPro7,1: AMD RX Polaris and newer(Note that MacPro7,1 is also a Catalina exclusive)
 * MacPro6,1: AMD R5/R7/R9 and older
-* iMac14,2: Nvidia Kepler and newer
+* iMac14,2: Nvidia Kepler and newer (Note: for Big Sur use MacPro7,1)
 
 Run GenSMBIOS, pick option 1 for downloading MacSerial and Option 3 for selecting out SMBIOS.  This will give us an output similar to the following:
 


### PR DESCRIPTION
iMac14.2 is not compatible with Big Sur (MacPro7,1 is a alternative for Zen and Kepler)