### PR TITLE
Some technical fixes

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -25,7 +25,8 @@ div[class*="language-"]
     margin-top 0
 
 html {
-  overflow:   scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 ::-webkit-scrollbar {
     width 0px

--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -27,6 +27,7 @@ div[class*="language-"]
 html {
   overflow-y: scroll;
   overflow-x: hidden;
+  background-color: unset;
 }
 ::-webkit-scrollbar {
     width 0px


### PR DESCRIPTION
ec875ef: This commit removes horizontal scrollbar by `overflow-x: hidden;`. However, vertical scrollbar remains set to the `scroll` value.
af448c0: Thanks to @Mirdukkk for researching and solving this issue. As Mirdukkk researched, the body was not fully stretched.
<details>
  <summary>Screenshots</summary>
Two fixes are shown in both dark and light themes:

![Снимок экрана 2021-02-22 в 22 00 26](https://user-images.githubusercontent.com/48864283/108742286-614e6980-7559-11eb-8a71-369619361510.png)
![Снимок экрана 2021-02-22 в 21 37 39](https://user-images.githubusercontent.com/48864283/108742496-91960800-7559-11eb-8d66-a53e9ecba7db.png)

Removing horizontal scrollbar in html does not affect to content with scrollbars (weird wording of the sentence, see screenshot below):

![Снимок экрана 2021-02-22 в 21 35 25](https://user-images.githubusercontent.com/48864283/108742860-049f7e80-755a-11eb-98e7-10a5c6f3b744.png)

As you can see, the scrollbar remains. 
</details>