### PR TITLE
Update MacInstall script to avoid error

### DIFF
--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -18,7 +18,7 @@ For machines that need a specific OS release or can't download from the App Stor
 In order to run it, just copy and paste the below command in a terminal window:
 
 ```sh
-mkdir ~/macOS-installer && cd ~/macOS-installer && curl -O https://raw.githubusercontent.com/munki/macadmin-scripts/main/installinstallmacos.py && sudo python installinstallmacos.py
+[ ! -d ~/macOS-installer/ ] && mkdir ~/macOS-installer; cd ~/macOS-installer; [ ! -f ~/macOS-installer/installinstallmacos.py ] && curl -O https://raw.githubusercontent.com/munki/macadmin-scripts/main/installinstallmacos.py; sudo python installinstallmacos.py
 ```
 
 ![](../images/installer-guide/mac-install-md/munki.png)


### PR DESCRIPTION
When the file or the folder already existed, curl and mkdir gave an error. I added an if to avoid it