### PR TITLE
why-oc.md: fix broken link

### DIFF
--- a/why-oc.md
+++ b/why-oc.md
@@ -8,7 +8,7 @@ This section contains a brief rundown as to why the community has been transitio
   * OpenCore features
   * Software support
   * Kext injection
-* [OpenCore's shortcomings](#opencores-shortcomings)
+* [OpenCore's shortcomings](#opencore-s-shortcomings)
 * [Common Myths](#common-myths)
   * Is OpenCore unstable as it's a beta?
   * Does OpenCore always inject SMBIOS and ACPI data into other OSes?


### PR DESCRIPTION
The link I'm proposing changing does not work at https://dortania.github.io/OpenCore-Install-Guide/why-oc.html.

Though I have not been able to test re-building the pages and viewing and checking, the required link seems to be what I've updated it to here.