### PR TITLE
Added 6000-series as supported GPUs

### DIFF
--- a/macos-limits.md
+++ b/macos-limits.md
@@ -201,7 +201,7 @@ Note: Apple has kept Ivy Bridge's iGPU drivers present in macOS 11, Big Sur, how
 | [Vega 10](https://en.wikipedia.org/wiki/Radeon_RX_Vega_series) | 10.12.6 | ^^ | ^^ |
 | [Vega 20](https://en.wikipedia.org/wiki/Radeon_RX_Vega_series) | 10.14.5 | ^^ | ^^ |
 | [Navi 10](https://en.wikipedia.org/wiki/Radeon_RX_5000_series) | 10.15.1 | ^^ | Requires `agdpmod=pikera` in boot-args |
-| [Navi 20](https://en.wikipedia.org/wiki/Radeon_RX_6000_series) | <span style="color:red"> N/A </span> | <span style="color:red"> N/A </span> | <span style="color:red"> Current drivers do not function </span> |
+| [Navi 20](https://en.wikipedia.org/wiki/Radeon_RX_6000_series) | 11.4 beta | ^^ | Currently only 6800, 6800XT and 6900XT are supported |
 
 :::
 


### PR DESCRIPTION
Big Sur 11.4 beta [officially added support](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_4-beta-release-notes#Overview) for AMD's 6000-series cards. Support is currently restricted to 6800, 6800XT and 6900XT cards. 