### PR TITLE
Removed unneeded use of `cat`

### DIFF
--- a/find-hardware.md
+++ b/find-hardware.md
@@ -109,7 +109,6 @@ Due to OEMs not providing much details about the drive, you'll need to Google a 
 
 For finding hardware using Linux, we'll be using a few tools:
 
-* `cat`
 * `pciutils`
 * `dmidecode`
 
@@ -118,7 +117,7 @@ Below you'll find a list of commands to run in the terminal, thankfully most Lin
 ### CPU Model
 
 ```sh
-cat /proc/cpuinfo | grep -i "model name"
+grep -i "model name" /proc/cpuinfo
 ```
 
 ### GPU Model


### PR DESCRIPTION
Very tiny change in the Linux section of the "Finding hardware" page. No files need to be concatenated and `grep` takes file names as argument so it's [not a very useful use of cat](http://www.smallo.ruhr.de/award.html) ;)