### PR TITLE
fix link for busid igpu patching

### DIFF
--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -135,7 +135,7 @@ We also add 2 more properties, `framebuffer-patch-enable` and `framebuffer-stole
 
 * **Note**: Headless framebuffers(where the dGPU is the display out) do not need `framebuffer-patch-enable` and `framebuffer-stolenmem`
 
-For users with black screen issues after verbose on B360, B365, H310, H370, Z390, please see the [BusID iGPU patching](https://dortania.github.io/OpenCore-Post-Install/gpu-patching/intel-patching/) page
+For users with black screen issues after verbose on B360, B365, H310, H370, Z390, please see the [BusID iGPU patching](https://dortania.github.io/OpenCore-Post-Install/gpu-patching/intel-patching/busid.html) page
 
 | Key | Type | Value |
 | :--- | :--- | :--- |


### PR DESCRIPTION
was originally going to the intel-patching root area, updated ver goes straight to busid.html