### PR TITLE
Change SSDT-CPUR link to maintained repo

### DIFF
--- a/ktext.md
+++ b/ktext.md
@@ -411,7 +411,7 @@ A quick TL;DR of needed SSDTs(This is source code, you will have to compile them
 | Coffee Lake | ^^ | ^^ | [SSDT-AWAC](https://dortania.github.io/Getting-Started-With-ACPI/Universal/awac.html) | [SSDT-PMC](https://dortania.github.io/Getting-Started-With-ACPI/Universal/nvram.html) | ^^ |
 | Comet Lake | ^^ | ^^ | ^^ | N/A | [SSDT-RHUB](https://dortania.github.io/Getting-Started-With-ACPI/Universal/rhub.html) |
 | AMD (15/16h) | N/A | ^^ | N/A | ^^ | N/A |
-| AMD (17/19h) | [SSDT-CPUR for B550 and A520](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-CPUR.aml) | ^^ | ^^ | ^^ | ^^ |
+| AMD (17/19h) | [SSDT-CPUR for B550 and A520](https://github.com/naveenkrdy/Misc/blob/master/SSDTs/Compiled/SSDT-CPUR.aml) | ^^ | ^^ | ^^ | ^^ |
 
 ### High End Desktop
 


### PR DESCRIPTION
The compiled version of SSDT-CPUR linked to in the guide is outdated. The SHA256 hash of the latest build of it should be 4a551bb2cbb6ca6401ef82c4a2696b9b0fa65cfb2e38e4b17243763b31554f67. I was specifically asked by XLNC in the AMD OS X discord server to make this pull request and link to his compiled version of SSDT-CPUR as he will be maintaining it in the future.

Someone in the AMD OS X server couldn't boot macOS with the currently linked prebuilt, but was successful after compiling it with iASL themselves, so I'd say that this is a pretty needed change.

Closed #297 because I accidentally committed other changes to it.