### PR TITLE
Mention AMD kernel patch edit requirement

### DIFF
--- a/AMD/fx.md
+++ b/AMD/fx.md
@@ -238,6 +238,7 @@ To merge:
 * Delete the `Kernel -> Patch` section from config.plist
 * Copy the `Kernel -> Patch` section from patches.plist
 * Paste into where old patches were in config.plist
+* Make sure to **read the README** for the [kernel patches GitHub repository](https://github.com/AMD-OSX/AMD_Vanilla/tree/master) as there are changes required to the `Replace` fields of some patches. Simply copying the patches into your config is not enough and will cause your installation to get stuck on preboot.
 
 ![](../images/config/AMD/kernel.gif)
 

--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -253,6 +253,7 @@ To merge:
 * Delete the `Kernel -> Patch` section from config.plist
 * Copy the `Kernel -> Patch` section from patches.plist
 * Paste into where old patches were in config.plist
+* Make sure to **read the README** for the [kernel patches GitHub repository](https://github.com/AMD-OSX/AMD_Vanilla/tree/master) as there are changes required to the `Replace` fields of some patches. Simply copying the patches into your config is not enough and will cause your installation to get stuck on preboot.
 
 ![](../images/config/AMD/kernel.gif)
 


### PR DESCRIPTION
On the AMD OS X Discord server, at least 80% of people's issues are getting stuck on preboot (namely `[EB|#LOG:EXITBS:START]`) because they aren't told by the guide to read the README for the AMD-OSX/AMD_Vanilla repository. In the README, it tells users how to edit the `Replace` field of the first 3 patches to avoid this problem.

This branch just simply adds a note at the bottom of the `Kernel -> Patch` sections of the Ryzen and FX config.plist guides to read the README before proceeding with the rest of the guide.