### PR TITLE
Update Disable GPU via DeviceProperties Method

### DIFF
--- a/extras/spoof.md
+++ b/extras/spoof.md
@@ -37,11 +37,9 @@ With this, navigate towards `Root -> DeviceProperties -> Add` and add your PCI r
 
 | Key | Type | Value |
 | :--- | :--- | :--- |
-| name | Data | `23646973706C6179` |
-| IOName | string | #display |
-| class-code | Data | `FFFFFFFF` |
+| disable-gpu | Boolean | `True` |
 
-![](../images/extras/spoof-md/config-gpu.png)
+![](https://user-images.githubusercontent.com/8745545/140165849-bd67d808-90b0-462c-adf4-e9b7700f17a4.png)
 
 ### SSDT Method
 


### PR DESCRIPTION
Updated the DeviceProperties Method for the new "disable-gpu" key supported by WhateverGreen 0.4.9