### PR TITLE
Use Apple's python instead of relying on $PATH

### DIFF
--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -16,7 +16,7 @@ For machines that need a specific OS release or can't download from the App Stor
 In order to run it, just copy and paste the below command in a terminal window:
 
 ```sh
-mkdir -p ~/macOS-installer && cd ~/macOS-installer && curl https://raw.githubusercontent.com/munki/macadmin-scripts/main/installinstallmacos.py > installinstallmacos.py && sudo python installinstallmacos.py
+mkdir -p ~/macOS-installer && cd ~/macOS-installer && curl https://raw.githubusercontent.com/munki/macadmin-scripts/main/installinstallmacos.py > installinstallmacos.py && sudo /usr/bin/python installinstallmacos.py
 ```
 
 ![](../images/installer-guide/mac-install-md/munki.png)


### PR DESCRIPTION
If a user has installed their own python e.g. with homebrew, it will not include xattr and installinstallmacos.py will fail. Referencing /usr/bin/python instead will use Apple's python distribution which includes the required xattr.