### PR TITLE
Change "Format to FAT32" to "Format to HFS+"

### DIFF
--- a/installer-guide/mac-install-recovery.md
+++ b/installer-guide/mac-install-recovery.md
@@ -56,9 +56,9 @@ From here, run one of those commands in terminal and once finished you'll get an
 
 ![](../images/installer-guide/legacy-mac-install-md/download-done.png)
 
-Once this is done, format your USB as FAT32 with GUID Partition Scheme:
+Once this is done, format your USB as "Mac OS Extended (Journaled)" with GUID Partition Scheme:
 
-![](../images/installer-guide/legacy-mac-install-md/fat32-erase.png)
+![]<img width="1066" alt="hfs-erase" src="https://user-images.githubusercontent.com/98128203/150429988-788598a4-080c-4434-a001-dc7b235802fd.png">
 
 And finally, create folder on the root of this drive called `com.apple.recovery.boot` and place the newly downloaded BaseSystem/RecoveryImage files in:
 


### PR DESCRIPTION
I was NOT able to install legacy OS X (Mountain Lion) with online/recovery-only installer on a FAT32 USB stick.  On 2 separate attempts, I only had success with an HFS+ formatted drive.  Formatting the drive as FAT32 will cause "Install OS X Mountain Lion" to do not appears in the OpenCore picker even with HideAuxiliary set to False.  As soon as I formatted as HFS+ and repeated the steps, the installer was accessible and installed with no issues.

If FAT32 is indeed incorrect, this should be corrected.  Thanks.