### PR TITLE
I211 on macOS 12 Montery doesn't work with SmallTreeIntel82576 kext

### DIFF
--- a/dictionary/dictionary.txt
+++ b/dictionary/dictionary.txt
@@ -153,6 +153,7 @@ AppleHDAInput
 AppleHV
 AppleHV's
 AppleID
+AppleIGB
 AppleIntelCPUPM
 AppleIntelCPUPowerManagement
 AppleIntelCPUPowerManagment
@@ -218,6 +219,7 @@ Baudrate
 BeyondCompare
 Big
 BlueScreen
+BlueToolFixup
 BootCamp
 BootInstall
 Bootable
@@ -258,6 +260,8 @@ CPUID's
 CPUs
 CR0
 CSM
+CSR_ALLOW_APPLE_INTERNAL
+CSR_ALLOW_UNAUTHENTICATED_ROOT
 Capitan
 Carcraftz
 Celeron
@@ -1023,6 +1027,7 @@ backlight
 backports
 base64
 bitmask
+bluetooth
 boot-arg
 boot-args
 boot-args.
@@ -1277,6 +1282,7 @@ unenroll
 unmount
 unoptimized
 untrusted
+uploader
 userspace
 v1
 v2

--- a/extras/monterey.md
+++ b/extras/monterey.md
@@ -95,7 +95,7 @@ Where `<core count>` is replaced with the physical core count of your CPU in hex
 
 Note that all cards have not been fixed yet, and that bluetooth support is being worked on still.
 
-Do not be suprised if your card does not work, and please be patient!
+Do not be surprised if your card does not work, and please be patient!
 
 :::
 
@@ -116,6 +116,16 @@ See the below issues for more details:
 
 * [BlueToolFixup PR](https://github.com/acidanthera/BrcmPatchRAM/pull/12)
 * [Monterey Beta 5+ issues](https://github.com/acidanthera/bugtracker/issues/1821)
+
+### Ethernet
+
+Intel I211 chipset (typical for some AMD boards i.e. B450) no longer works with SmallTreeIntel82576 kext (network remains in `Cable Unplugged` status).
+
+[AppleIGB](https://github.com/Shaneee/AppleIGB) might work on some systems but it has a known issue to drop connections (primarily after wake-up).
+
+See the below issues for more details:
+
+* [Kext no longer working with MacOS 12.0](https://github.com/khronokernel/SmallTree-I211-AT-patch/issues/3)
 
 ### OTA Updates
 

--- a/ktext.md
+++ b/ktext.md
@@ -140,7 +140,8 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * Intel's 82578, 82579, I217, I218 and I219 NICs are officially supported
   * Requires OS X 10.9 or newer, 10.6-10.8 users can use the IntelSnowMausi instead for older OSes
 * [SmallTreeIntel82576 kext](https://github.com/khronokernel/SmallTree-I211-AT-patch/releases)
-  * Required for I211 NICs, based off of the SmallTree kext but patched to support I211
+  * Required for I211 NICs, based off of the SmallTree kext but patched to support I211 (doesn't work on macOS 12 [Monterey](./extras/monterey.md#ethernet)
+)
   * Required for most AMD boards running Intel NICs
   * Requires OS X 10.9-12(v1.0.6), macOS 10.13-14(v1.2.5), macOS 10.15+(v1.3.0)
 * [AtherosE2200Ethernet](https://github.com/Mieze/AtherosE2200Ethernet/releases)


### PR DESCRIPTION
Hi guys,

I am not the only one having this [issue](https://github.com/khronokernel/SmallTree-I211-AT-patch/issues/3).

So it would make sense probably to update the guide.

P.s. AppleIGB partially solves the issue but it has it's own problems.
