### PR TITLE
Update zen.md

### DIFF
--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -279,7 +279,6 @@ Where `<core count>` is replaced with the physical core count of your CPU in hex
 | 16 Core | `10` |
 | 24 Core | `18` |
 | 32 Core | `20` |
-| 64 Core | `40` |
 
 :::
 


### PR DESCRIPTION
Today OSX limit is 64 Cores or 32cores+32threads
3990x has a total of 128 cores (64 cores + 64 threads)
if a 3990x user put a value of 40 as suggested in Core Count patch his system will be hang in early stage
3990x have to force their BIOS to use only 64 Cores or 32cores + 32 threads and to use 20 in Core Count Kernel patch