### PR TITLE
adding Big Sur MinVersion and MinDate to tip APFS Versions

### DIFF
--- a/AMD/fx.md
+++ b/AMD/fx.md
@@ -672,6 +672,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -692,6 +692,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/broadwell-e.md
+++ b/config-HEDT/broadwell-e.md
@@ -633,6 +633,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/broadwell-e.md
+++ b/config-HEDT/broadwell-e.md
@@ -162,6 +162,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-HEDT/haswell-e.md
+++ b/config-HEDT/haswell-e.md
@@ -633,6 +633,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/haswell-e.md
+++ b/config-HEDT/haswell-e.md
@@ -162,6 +162,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-HEDT/ivy-bridge-e.md
+++ b/config-HEDT/ivy-bridge-e.md
@@ -594,6 +594,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/ivy-bridge-e.md
+++ b/config-HEDT/ivy-bridge-e.md
@@ -172,6 +172,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-HEDT/nehalem.md
+++ b/config-HEDT/nehalem.md
@@ -182,6 +182,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-HEDT/nehalem.md
+++ b/config-HEDT/nehalem.md
@@ -609,6 +609,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/skylake-x.md
+++ b/config-HEDT/skylake-x.md
@@ -596,6 +596,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-HEDT/skylake-x.md
+++ b/config-HEDT/skylake-x.md
@@ -178,6 +178,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/arrandale.md
+++ b/config-laptop.plist/arrandale.md
@@ -223,6 +223,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/arrandale.md
+++ b/config-laptop.plist/arrandale.md
@@ -637,6 +637,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/broadwell.md
+++ b/config-laptop.plist/broadwell.md
@@ -223,6 +223,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/broadwell.md
+++ b/config-laptop.plist/broadwell.md
@@ -646,6 +646,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -693,6 +693,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -254,6 +254,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -245,6 +245,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -661,6 +661,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/haswell.md
+++ b/config-laptop.plist/haswell.md
@@ -657,6 +657,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/haswell.md
+++ b/config-laptop.plist/haswell.md
@@ -225,6 +225,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -238,6 +238,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -655,6 +655,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/ivy-bridge.md
+++ b/config-laptop.plist/ivy-bridge.md
@@ -704,6 +704,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/ivy-bridge.md
+++ b/config-laptop.plist/ivy-bridge.md
@@ -268,6 +268,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -657,6 +657,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -242,6 +242,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/sandy-bridge.md
+++ b/config-laptop.plist/sandy-bridge.md
@@ -674,6 +674,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/sandy-bridge.md
+++ b/config-laptop.plist/sandy-bridge.md
@@ -255,6 +255,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config-laptop.plist/skylake.md
+++ b/config-laptop.plist/skylake.md
@@ -650,6 +650,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config-laptop.plist/skylake.md
+++ b/config-laptop.plist/skylake.md
@@ -234,6 +234,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/clarkdale.md
+++ b/config.plist/clarkdale.md
@@ -184,6 +184,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/clarkdale.md
+++ b/config.plist/clarkdale.md
@@ -614,6 +614,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -218,6 +218,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -646,6 +646,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/comet-lake.md
+++ b/config.plist/comet-lake.md
@@ -685,6 +685,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/comet-lake.md
+++ b/config.plist/comet-lake.md
@@ -229,6 +229,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/haswell.md
+++ b/config.plist/haswell.md
@@ -210,6 +210,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/haswell.md
+++ b/config.plist/haswell.md
@@ -654,6 +654,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/ivy-bridge.md
+++ b/config.plist/ivy-bridge.md
@@ -228,6 +228,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/ivy-bridge.md
+++ b/config.plist/ivy-bridge.md
@@ -676,6 +676,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/kaby-lake.md
+++ b/config.plist/kaby-lake.md
@@ -621,6 +621,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/kaby-lake.md
+++ b/config.plist/kaby-lake.md
@@ -194,6 +194,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/penryn.md
+++ b/config.plist/penryn.md
@@ -606,6 +606,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/penryn.md
+++ b/config.plist/penryn.md
@@ -185,6 +185,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/sandy-bridge.md
+++ b/config.plist/sandy-bridge.md
@@ -667,6 +667,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::

--- a/config.plist/sandy-bridge.md
+++ b/config.plist/sandy-bridge.md
@@ -237,6 +237,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/skylake.md
+++ b/config.plist/skylake.md
@@ -202,6 +202,7 @@ A reminder that [ProperTree](https://github.com/corpnewt/ProperTree) users can r
 | 10.14 | 18.0.0 | 18.99.99 |
 | 10.15 | 19.0.0 | 19.99.99 |
 | 11 | 20.0.0 | 20.99.99 |
+| 12 | 21.0.0 | 21.99.99 |
 
 :::
 

--- a/config.plist/skylake.md
+++ b/config.plist/skylake.md
@@ -624,6 +624,7 @@ Both MinVersion and MinDate need to be set if changing the minimum version.
 | High Sierra (`10.13.6`) | `748077008000000` | `20180621` |
 | Mojave (`10.14.6`) | `945275007000000` | `20190820` |
 | Catalina (`10.15.4`) | `1412101001000000` | `20200306` |
+| Big Sur (`11.4`) | `1677120009000000` | `20210508` |
 | No restriction | `-1` | `-1` |
 
 :::


### PR DESCRIPTION
adding Big Sur MinDate and MinVersion to tip APFS Versions base on https://github.com/acidanthera/OpenCorePkg/blob/master/Include/Acidanthera/Library/OcApfsLib.h