### PR TITLE
Add info for enabling I225-V on 12.3+

### DIFF
--- a/extras/monterey.md
+++ b/extras/monterey.md
@@ -127,6 +127,8 @@ See the below issues for more details:
 
 * [Kext no longer working with MacOS 12.0](https://github.com/khronokernel/SmallTree-I211-AT-patch/issues/3)
 
+The boot-arg for enabling Intel I225-V ethernet controller has changed since macOS Monterey 12.3. Use `e1000=0` instead of `dk.e1000=0`.
+
 ### OTA Updates
 
 Starting with Monterey, updates are not delivered to T2 Macs which don't have Secure Boot enabled, and updates do not install properly if your SecureBootModel does not match your machine (ie. non-T2 SMBIOS using j137 or iMacPro1,1 using j160). Hackintoshes which use a T2 SMBIOS **MUST** have OpenCore 0.7.4+ with SecureBootModel set to `Default`. If your SMBIOS does not have a T2 chip, then either `Default` or `Disabled` is ok. More information is available on the [Apple Secure Boot page](https://dortania.github.io/OpenCore-Post-Install/universal/security/applesecureboot.html).


### PR DESCRIPTION
Add the updated boot-arg to prevent freezes on macOS 12.3+