### PR TITLE
Fix typo in `kernel-debugging.md`

### DIFF
--- a/troubleshooting/kernel-debugging.md
+++ b/troubleshooting/kernel-debugging.md
@@ -26,7 +26,7 @@ For serial setup, OpenCore actually makes this quite straight forward.
 
 ### Misc
 
-* **SerialInt**: YES
+* **SerialInit**: YES
   * Performs serial port initialization
 * **Target**: `67`
   * Enables debug output with OpenCore


### PR DESCRIPTION
`SerialInt` => `SerialInit`
