### PR TITLE
Update ktext.md

### DIFF
--- a/ktext.md
+++ b/ktext.md
@@ -150,7 +150,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * Note: Atheros Killer E2500 models are actually Realtek based, for these systems please use [RealtekRTL8111](https://github.com/Mieze/RTL8111_driver_for_OS_X/releases) instead
 * [RealtekRTL8111](https://github.com/Mieze/RTL8111_driver_for_OS_X/releases)
   * For Realtek's Gigabit Ethernet
-  * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for versions v2.2.2 through v2.3.0 (inclusive), macOS 10.14 and up for versions v2.4.0 and up
+  * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
 * [LucyRTL8125Ethernet](https://www.insanelymac.com/forum/files/file/1004-lucyrtl8125ethernet/)
   * For Realtek's 2.5Gb Ethernet


### PR DESCRIPTION
From: https://github.com/Mieze/RTL8111_driver_for_OS_X

Changelog

Version 2.3.0 (2020-08-14)
Reworked medium section and EEE support to resolve problems with connection establishment and stability.
Added option to supply a fallback MAC.
Updated Linux sources to 8.047.04 and added support for new family members
Requires 10.14 or newer.