### PR TITLE
Update zen.md due 0.8.1

### DIFF
--- a/AMD/zen.md
+++ b/AMD/zen.md
@@ -416,7 +416,6 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 
 | Quirk | Enabled | Comment |
 | :--- | :--- | :--- |
-| AllowNvramReset | YES | |
 | AllowSetDefault | YES | |
 | BlacklistAppleUpdate | YES | |
 | ScanPolicy | 0 | |
@@ -427,8 +426,6 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 
 ::: details More in-depth Info
 
-* **AllowNvramReset**: YES
-  * Allows for NVRAM reset both in the boot picker and when pressing `Cmd+Opt+P+R`
 * **AllowSetDefault**: YES
   * Allow `CTRL+Enter` and `CTRL+Index` to set default boot device in the picker
 * **ApECID**: 0


### PR DESCRIPTION
Due to changes on 0.8.1, as AllowNvramReset was removed, it is causing people a bit confusing and often asking the same question on #post_install chat in Discord.
As long it is not needed, I thought to remove it and keep simple for people just reading the guide.