### PR TITLE
Add OS X 10.7 and 10.8 to Offline method guide

### DIFF
--- a/installer-guide/mac-install-pkg.md
+++ b/installer-guide/mac-install-pkg.md
@@ -1,10 +1,20 @@
 # Legacy macOS: Offline method
 
-This method allows us to download full installers from Apple, however is limited to 10.10, Yosemite, so older OSes will need to be grabbed via the "Online Method" mentioned below.
+This method allows us to download full installers from Apple, however is limited to the macOS versions listed below:
 
-To start, go to the following link:
+* 10.7 Lion
+* 10.8 Mountain Lion
+* 10.10 Yosemite
+* 10.11 El Capitan
+* 10.12 Sierra
 
-* [How to get old versions of macOS](https://support.apple.com/en-us/HT211683)
+Note that OS X 10.9 Mavericks is not available from Apple yet. It will need to be grabbed via the "Online Method" mentioned below.
+
+To start, go to one of the following links:
+
+* [Mac OS X Lion Installer](https://support.apple.com/kb/DL2077?locale=en_US)
+* [Mac OS X Mountain Lion Installer](https://support.apple.com/kb/DL2076?locale=en_US)
+* [How to get old versions of macOS](https://support.apple.com/en-us/HT211683) (for 10.10 - 10.12 installers)
 
 Download your desired version and a .pkg file should be provided.
 
@@ -42,6 +52,24 @@ xar -xf /Volumes/Install\ macOS/InstallOS.pkg
 ```
 
 Next, run the following(one at a time):
+
+* Lion:
+
+```sh
+cd InstallMacOSX.pkg
+tar xvzf Payload
+mv InstallESD.dmg Install\ Mac\ OS\ X\ Lion.app/Contents/SharedSupport/
+mv Install\ Mac\ OS\ X\ Lion.app /Applications
+```
+
+* Mountain Lion:
+
+```sh
+cd InstallMacOSX.pkg
+tar xvzf Payload
+mv InstallESD.dmg Install\ Mac\ OS\ X\ Mountain\ Lion.app/Contents/SharedSupport/
+mv Install\ Mac\ OS\ X\ Mountain\ Lion.app /Applications
+```
 
 * Yosemite:
 

--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -67,7 +67,7 @@ From here, jump to [Setting up the installer](#setting-up-the-installer) to fini
 * This method allows you to download much older versions of OS X, currently supporting all Intel versions of OS X(10.4 to current)
 
   * [Legacy macOS: Offline method](./mac-install-pkg.md)
-    * 10.10-10.12 Supported
+    * 10.7-10.12 Supported, excluding 10.9
   * [Legacy macOS: Online method(10.7-10.15 Supported)](./mac-install-recovery.md)
     * 10.7-11 Supported
   * [Legacy macOS: Disk Images](./mac-install-dmg.md)


### PR DESCRIPTION
Apple has made Mac OS X 10.7 Lion and 10.8 Mountain Lion available for downloading from their website, so it's a good reason to add links to them. Dit not test creating the .app for ML though, but it should be the same as Lion one.