### PR TITLE
fix: apple silicon bootable USB for older MacOS versions

### DIFF
--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -88,21 +88,14 @@ sudo /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/createinstall
 
 ::: details Note for users on Apple Silicon installing macOS older than Big Sur
 
-If the `createinstallmedia` fails with `zsh: killed` or `Killed: 9` then it's most likely an issue with the `createinstallmedia` script signature. To fix this, you can run the following command:
+If the `createinstallmedia` fails with `zsh: killed` or `Killed: 9` then it's most likely an issue with the installer's code signature. To fix this, you can run the following command:
 
 ```sh
 cd /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/
-codesign -s - -f createinstallmedia
+codesign -s - -f --deep /Applications/Install\ macOS\ Big\ Sur.app
 ```
 
-If it still errors, you can try to codesign *every* file in `Contents/Resources/`
-
-```sh
-cd /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/
-find . -type f -exec codesign -s - -f "{}" \;
-```
-
-You might also have to install the XCode command line tools if `codesign` doesn't work.
+You will need the command line tools for Xcode installed:
 
 ```sh
 xcode-select --install

--- a/installer-guide/mac-install.md
+++ b/installer-guide/mac-install.md
@@ -86,6 +86,30 @@ Next run the `createinstallmedia` command provided by [Apple](https://support.ap
 sudo /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume
 ```
 
+::: details Note for users on Apple Silicon installing macOS older than Big Sur
+
+If the `createinstallmedia` fails with `zsh: killed` or `Killed: 9` then it's most likely an issue with the `createinstallmedia` script signature. To fix this, you can run the following command:
+
+```sh
+cd /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/
+codesign -s - -f createinstallmedia
+```
+
+If it still errors, you can try to codesign *every* file in `Contents/Resources/`
+
+```sh
+cd /Applications/Install\ macOS\ Big\ Sur.app/Contents/Resources/
+find . -type f -exec codesign -s - -f "{}" \;
+```
+
+You might also have to install the XCode command line tools if `codesign` doesn't work.
+
+```sh
+xcode-select --install
+```
+
+:::
+
 This will take some time so you may want to grab a coffee or continue reading the guide (to be fair you really shouldn't be following this guide step by step without reading the whole thing first).
 
 You can also replace the `createinstallmedia` path with that of where your installer's located (same idea with the drive name).


### PR DESCRIPTION
I ran into this issue trying to create a bootable High Sierra USB on my M2 MacBook, found [a fix that worked for me](https://forums.macrumors.com/threads/you-cant-use-an-m1-mac-to-create-bootable-pre-bigsur-macos-installers.2283560/) and thought it should probably be in the install guide.