### PR TITLE
[IRI] Winblows Installation

### DIFF
--- a/installer-guide/winblows-install.md
+++ b/installer-guide/winblows-install.md
@@ -9,7 +9,7 @@ To start you'll need the following:
 * For USB larger than 16 GB to format in FAT32 use [Rufus method](#rufus-method)
 
 * [macrecovery.py](https://github.com/acidanthera/OpenCorePkg/releases)
-  * This will require [Python installed](https://www.python.org/downloads/)
+  * This will require [Python 3 installed](https://www.python.org/downloads/)
 
 ## Downloading macOS
 
@@ -21,40 +21,40 @@ Now run one of the following depending on what version of macOS you want(Note th
 
 ```sh
 # Lion (10.7):
-python macrecovery.py -b Mac-2E6FAB96566FE58C -m 00000000000F25Y00 download
-python macrecovery.py -b Mac-C3EC7CD22292981F -m 00000000000F0HM00 download
+python3 macrecovery.py -b Mac-2E6FAB96566FE58C -m 00000000000F25Y00 download
+python3 macrecovery.py -b Mac-C3EC7CD22292981F -m 00000000000F0HM00 download
 
 # Mountain Lion (10.8):
-python macrecovery.py -b Mac-7DF2A3B5E5D671ED -m 00000000000F65100 download
+python3 macrecovery.py -b Mac-7DF2A3B5E5D671ED -m 00000000000F65100 download
 
 # Mavericks (10.9):
-python macrecovery.py -b Mac-F60DEB81FF30ACF6 -m 00000000000FNN100 download
+python3 macrecovery.py -b Mac-F60DEB81FF30ACF6 -m 00000000000FNN100 download
 
 # Yosemite (10.10):
-python macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000GDVW00 download
+python3 macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000GDVW00 download
 
 # El Capitan (10.11):
-python macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000GQRX00 download
+python3 macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000GQRX00 download
 
 # Sierra (10.12):
-python macrecovery.py -b Mac-77F17D7DA9285301 -m 00000000000J0DX00 download
+python3 macrecovery.py -b Mac-77F17D7DA9285301 -m 00000000000J0DX00 download
 
 # High Sierra (10.13)
-python macrecovery.py -b Mac-7BA5B2D9E42DDD94 -m 00000000000J80300 download
-python macrecovery.py -b Mac-BE088AF8C5EB4FA2 -m 00000000000J80300 download
+python3 macrecovery.py -b Mac-7BA5B2D9E42DDD94 -m 00000000000J80300 download
+python3 macrecovery.py -b Mac-BE088AF8C5EB4FA2 -m 00000000000J80300 download
 
 # Mojave (10.14)
-python macrecovery.py -b Mac-7BA5B2DFE22DDD8C -m 00000000000KXPG00 download
+python3 macrecovery.py -b Mac-7BA5B2DFE22DDD8C -m 00000000000KXPG00 download
 
 # Catalina (10.15)
-python macrecovery.py -b Mac-00BE6ED71E35EB86 -m 00000000000000000 download
+python3 macrecovery.py -b Mac-00BE6ED71E35EB86 -m 00000000000000000 download
 
 # Big Sur (11)
-python macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
+python3 macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 
 # Latest version
 # ie. Monterey (12)
-python ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
+python3 macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.


### PR DESCRIPTION
Updated commands from Python 2 to Python 3.
Since acidanthera/OpenCorePkg@719507f, macrecovery.py script was updated to support Python3+, therefore this guide has been updated