### PR TITLE
Fix references to latest version of macOS

### DIFF
--- a/installer-guide/linux-install.md
+++ b/installer-guide/linux-install.md
@@ -53,9 +53,12 @@ python3 ./macrecovery.py -b Mac-00BE6ED71E35EB86 -m 00000000000000000 download
 # Big Sur (11)
 python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 
-# Latest version
-# ie. Monterey (12)
+# Monterey (12)
 python3 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
+
+# Latest version
+# ie. Ventura (13)
+python3 ./macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 download
 ```
 
 From here, run one of those commands in terminal and once finished you'll get an output similar to this:

--- a/installer-guide/mac-install-recovery.md
+++ b/installer-guide/mac-install-recovery.md
@@ -41,9 +41,12 @@ python3 ./macrecovery.py -b Mac-00BE6ED71E35EB86 -m 00000000000000000 download
 # Big Sur (11)
 python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 
-# Latest version
-# ie. Monterey (12)
+# Monterey (12)
 python3 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
+
+# Latest version
+# ie. Ventura (13)
+python3 ./macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.

--- a/installer-guide/winblows-install.md
+++ b/installer-guide/winblows-install.md
@@ -52,9 +52,12 @@ python macrecovery.py -b Mac-00BE6ED71E35EB86 -m 00000000000000000 download
 # Big Sur (11)
 python macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 
+# Monterey (12)
+python3 ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
+
 # Latest version
-# ie. Monterey (12)
-python ./macrecovery.py -b Mac-E43C1C25D4880AD6 -m 00000000000000000 download
+# ie. Ventura (13)
+python3 ./macrecovery.py -b Mac-B4831CEBD52A0C4C -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.


### PR DESCRIPTION
Ventura is "stable" since November 9, 2022. Users following the guide will download Monterey instead of the latest version, because of device with dropped support.