### PR TITLE
Add fix that resolved kernel panics for some Chromebooks

### DIFF
--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -83,7 +83,9 @@ Settings relating to ACPI, leave everything here as default as we have no use fo
 
 ![Booter](../images/config/config-universal/aptio-iv-booter.png)
 
-This section is dedicated to quirks relating to boot.efi patching with OpenRuntime, the replacement for AptioMemoryFix.efi
+| Quirk | Enabled | Comment |
+| :--- | :--- | :--- |
+| ProtectMemoryReigons | YES | Only for specfic Chromebooks |
 
 ### MmioWhitelist
 


### PR DESCRIPTION
On some Chromebook models, shutting down or restarting would yield a `AppleEFINVRAM` kernel panic, which can be fixed by enabling ProtectMemoryReigons.

Update: Forgot to add that it will freeze up if connecting to Intel WiFi via. AirportItlwm on macOS 11 or newer, therefore leaving the user unable to connect to the internet and install the OS via internet recovery. 