### PR TITLE
Fix a typing error

### DIFF
--- a/extras/smbios-support.md
+++ b/extras/smbios-support.md
@@ -344,7 +344,7 @@ Extra information regarding Apple's CPUs:
 | SMBIOS | Year | CPU Family | Initial Support | Last Supported Version |
 | :--- | :--- | :--- | :--- | :--- |
 | PowerBook2,1 | Mid-1999 | PowerPC 750 (G3) | 8.6 | 10.3.9 |
-| PowerBook2,2 | Late 20000 | PowerPC 750cx (G3) | 9.0.4 | 10.4.11 |
+| PowerBook2,2 | Late 2000 | PowerPC 750cx (G3) | 9.0.4 | 10.4.11 |
 | PowerBook4,1 | Late 2002 | PowerPC 7455 (G4) | 9.2.2 | 10.5.8 |
 | PowerBook4,2 | Early 2002 | PowerPC 750cx (G3) | 9.2.1 | 10.4.11 |
 | PowerBook4,3 | Mid-2002 | PowerPC 750fx (G3) | 9.2.2 | ^^ |


### PR DESCRIPTION
In the iBook - PowerPC section the PowerBook 2,2's SMBIOS is labeled as being from "Late 20000"!  I don't know if you know something that I don't but I don't think that's correct.  

Summary: Change PowerBook 2,2's SMBIOS year to Late 2000.