### PR TITLE
Add Chromebook specific properties to Skylake and newer config.plist's

### DIFF
--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -557,7 +557,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
-|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
+| **-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -97,7 +97,7 @@ This section is allowing devices to be pass-through to macOS that are generally 
 ::: tip Info
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
-| Quirk | Enabled | Comments |
+| Quirk | Enabled | Comment |
 | :--- | :--- | :--- |
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -97,13 +97,15 @@ This section is allowing devices to be pass-through to macOS that are generally 
 ::: tip Info
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
-| Quirk | Enabled |
-| :--- | :--- |
+| Quirk | Enabled | Comments |
+| :--- | :--- | :--- |
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |
-| ProtectUefiServices | YES |
+| ProtectMemoryRegions| YES | Only for Chromebooks, leave default otherwise. |
+| ProtectUefiServices | YES | 
 | RebuildAppleMemoryMap | YES |
 | SyncRuntimePermissions | YES |
+
 :::
 
 ::: details More in-depth Info
@@ -117,6 +119,8 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 * **EnableWriteUnprotector**: NO
   * This quirk and RebuildAppleMemoryMap can commonly conflict, recommended to enable the latter on newer platforms and disable this entry.
   * However, due to issues with OEMs not using the latest EDKII builds you may find that the above combo will result in early boot failures. This is due to missing the `MEMORY_ATTRIBUTE_TABLE` and such we recommend disabling RebuildAppleMemoryMap and enabling EnableWriteUnprotector. More info on this is covered in the [troubleshooting section](/troubleshooting/extended/kernel-issues.md#stuck-on-eb-log-exitbs-start)
+* **ProtectMemoryRegions**: YES
+  * Patches memory region types for incorrectly mapped CSM/MMIO regions. Necessary for all Chromebooks that utilize coreboot UEFI firmware.
 * **ProtectUefiServices**: YES
   * Protects UEFI services from being overridden by the firmware, mainly relevant for VMs, Icelake and Z390 systems'
   * If on Z390, **enable this quirk**
@@ -553,6 +557,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
+|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -102,10 +102,9 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |
 | ProtectMemoryRegions| YES | Only for Chromebooks, leave disabled otherwise. |
-| ProtectUefiServices | YES | 
+| ProtectUefiServices | YES |
 | RebuildAppleMemoryMap | YES |
 | SyncRuntimePermissions | YES |
-
 :::
 
 ::: details More in-depth Info

--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -101,7 +101,7 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 | :--- | :--- | :--- |
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |
-| ProtectMemoryRegions| YES | Only for Chromebooks, leave default otherwise. |
+| ProtectMemoryRegions| YES | Only for Chromebooks, leave disabled otherwise. |
 | ProtectUefiServices | YES | 
 | RebuildAppleMemoryMap | YES |
 | SyncRuntimePermissions | YES |

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -526,7 +526,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
-|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
+| **-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -96,11 +96,13 @@ This section is allowing spaces to be pass-through to macOS that are generally i
 ::: tip Info
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
-| Quirk | Enabled |
-| :--- | :--- |
+| Quirk | Enabled | Comment |
+| :--- | :--- | :--- |
 | EnableWriteUnprotector | NO |
+| ProtectMemoryRegions| YES | Only for Chromebooks, leave disabled otherwise. |
 | RebuildAppleMemoryMap | YES |
 | SyncRuntimePermissions | YES |
+
 :::
 
 ::: details More in-depth Info
@@ -112,6 +114,8 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 * **EnableWriteUnprotector**: NO
   * This quirk and RebuildAppleMemoryMap can commonly conflict, recommended to enable the latter on newer platforms and disable this entry.
   * However, due to issues with OEMs not using the latest EDKII builds you may find that the above combo will result in early boot failures. This is due to missing the `MEMORY_ATTRIBUTE_TABLE` and such we recommend disabling RebuildAppleMemoryMap and enabling EnableWriteUnprotector. More info on this is covered in the [troubleshooting section](/troubleshooting/extended/kernel-issues.md#stuck-on-eb-log-exitbs-start)
+* **ProtectMemoryRegions**: YES
+  * Patches memory region types for incorrectly mapped CSM/MMIO regions. Necessary for all Chromebooks that utilize coreboot UEFI firmware.
 * **ProvideCustomSlide**: YES
   * Used for Slide variable calculation. However the necessity of this quirk is determined by `OCABC: Only N/256 slide values are usable!` message in the debug log. If the message `OCABC: All slides are usable! You can disable ProvideCustomSlide!` is present in your log, you can disable `ProvideCustomSlide`.
 * **RebuildAppleMemoryMap**: YES
@@ -522,6 +526,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
+|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -94,6 +94,7 @@ This section is allowing devices to be pass-through to macOS that are generally 
 ### Quirks
 
 ::: tip Info
+
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
 | Quirk | Enabled | Notes |

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -97,7 +97,7 @@ This section is allowing devices to be pass-through to macOS that are generally 
 
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
-| Quirk | Enabled | Notes |
+| Quirk | Enabled | Comment |
 | :--- | :--- | :--- |
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -96,16 +96,18 @@ This section is allowing devices to be pass-through to macOS that are generally 
 ::: tip Info
 Settings relating to boot.efi patching and firmware fixes, for us, we need to change the following:
 
-| Quirk | Enabled |
-| :--- | :--- |
+| Quirk | Enabled | Notes |
+| :--- | :--- | :--- |
 | DevirtualiseMmio | YES |
 | EnableWriteUnprotector | NO |
+| ProtectMemoryRegions | YES | Chromebooks only, fixes kernel panics triggered by shutdown/restart. |
 | ProtectUefiServices | YES |
 | RebuildAppleMemoryMap | YES |
 | SetupVirtualMap | NO |
-| SyncRuntimePermissions | YES |
-:::
+| SyncRuntimePermissions | YES | 
 
+
+:::
 ::: details More in-depth Info
 
 * **AvoidRuntimeDefrag**: YES
@@ -117,6 +119,8 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 * **EnableWriteUnprotector**: NO
   * This quirk and RebuildAppleMemoryMap can commonly conflict, recommended to enable the latter on newer platforms and disable this entry.
   * However, due to issues with OEMs not using the latest EDKII builds you may find that the above combo will result in early boot failures. This is due to missing the `MEMORY_ATTRIBUTE_TABLE` and such we recommend disabling RebuildAppleMemoryMap and enabling EnableWriteUnprotector. More info on this is covered in the [troubleshooting section](/troubleshooting/extended/kernel-issues.md#stuck-on-eb-log-exitbs-start)
+* **ProtectMemoryRegions**: YES
+  * Patches memory region types for incorrectly mapped CSM/MMIO regions. Necessary for all Chromebooks that utilize coreboot UEFI firmware.
 * **ProtectUefiServices**: YES
   * Protects UEFI services from being overridden by the firmware, mainly relevant for VMs, Icelake and Z390 systems'
   * If on Z390, **enable this quirk**
@@ -517,6 +521,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
+|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -522,7 +522,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
-|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
+| **-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -105,8 +105,7 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 | ProtectUefiServices | YES |
 | RebuildAppleMemoryMap | YES |
 | SetupVirtualMap | NO |
-| SyncRuntimePermissions | YES | 
-
+| SyncRuntimePermissions | YES |
 
 :::
 ::: details More in-depth Info

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -106,7 +106,6 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 | RebuildAppleMemoryMap | YES |
 | SetupVirtualMap | NO |
 | SyncRuntimePermissions | YES |
-
 :::
 ::: details More in-depth Info
 

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -92,6 +92,7 @@ This section is allowing spaces to be pass-through to macOS that are generally i
 ### Quirks
 
 ::: tip Info
+
 Settings relating to boot.efi patching and firmware fixes. For most users, leave it as default.
 
 * **ProtectMemoryRegions**: YES

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -605,7 +605,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
-|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
+| **-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information.
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/skylake.md
+++ b/config-laptop.plist/skylake.md
@@ -93,7 +93,12 @@ This section is allowing spaces to be pass-through to macOS that are generally i
 ### Quirks
 
 ::: tip Info
-Settings relating to boot.efi patching and firmware fixes, for us, we leave it as default
+
+Settings relating to boot.efi patching and firmware fixes. For most users, leave it as default.
+
+* **ProtectMemoryRegions**: YES
+  * Fixes shutdown/restart on some Chromebooks that would otherwise result in a `AppleEFINVRAM` kernel panic.
+
 :::
 ::: details More in-depth Info
 
@@ -103,6 +108,8 @@ Settings relating to boot.efi patching and firmware fixes, for us, we leave it a
   * Enables slide variables to be used in safe mode.
 * **EnableWriteUnprotector**: YES
   * Needed to remove write protection from CR0 register.
+* **ProtectMemoryRegions**: YES
+  * Patches memory region types for incorrectly mapped CSM/MMIO regions. Necessary for all Chromebooks that utilize coreboot UEFI firmware.
 * **ProvideCustomSlide**: YES
   * Used for Slide variable calculation. However the necessity of this quirk is determined by `OCABC: Only N/256 slide values are usable!` message in the debug log. If the message `OCABC: All slides are usable! You can disable ProvideCustomSlide!` is present in your log, you can disable `ProvideCustomSlide`.
 * **SetupVirtualMap**: YES
@@ -514,6 +521,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
+|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.

--- a/config-laptop.plist/skylake.md
+++ b/config-laptop.plist/skylake.md
@@ -521,7 +521,7 @@ System Integrity Protection bitmask
 | boot-args | Description |
 | :--- | :--- |
 | **-wegnoegpu** | Used for disabling all other GPUs than the integrated Intel iGPU, useful for those wanting to run newer versions of macOS where their dGPU isn't supported |
-|**-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
+| **-igfxnotelemetryload** | Prevents iGPU telemetry from loading. iGPU telemetry may cause a freeze during startup on certain laptops such as Chromebooks on macOS 10.15 and higher, see [here](https://github.com/acidanthera/WhateverGreen#intel-hd-graphics) for more information. |
 
 * **csr-active-config**: `00000000`
   * Settings for 'System Integrity Protection' (SIP). It is generally recommended to change this with `csrutil` via the recovery partition.


### PR DESCRIPTION
Added `ProtectMemoryRegions` under ACPI -> Booter -> Quirks to fix shutdown and restart on coreboot UEFI firmware that Chromebooks utilize and  `-igfxnotelemetryload` to fix iGPU acceleration on 10.15 and up.
