### PR TITLE
fix: correct the type of ESP in linux USB installer guide

### DIFF
--- a/config.plist/skylake.md
+++ b/config.plist/skylake.md
@@ -104,7 +104,7 @@ Sets device properties from a map.
 
 This section is set up via WhateverGreen's [Framebuffer Patching Guide](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md) and is used for setting important iGPU properties.
 
-The config.plist doesn't already have a section for this so you will have to create it manually.
+The config.plist doesn't already have a section for this so you will have to create it manually, and change its type to "**Data**".
 
 `AAPL,ig-platform-id` is what macOS uses to determine how the iGPU drivers interact with our system, and the two values choose between are as follows:
 

--- a/installer-guide/linux-install.md
+++ b/installer-guide/linux-install.md
@@ -95,7 +95,7 @@ In terminal:
       1. `partition number`: keep blank for default
       2. `first sector`: keep blank for default
       3. `last sector`: keep blank for whole disk
-      4. `Hex code or GUID`: `0700` for Microsoft basic data partition type
+      4. `Hex code or GUID`: `EF00` for EFI system partition type
    5. send `w`
       * Confirm with `y`
       ![](../images/installer-guide/linux-install-md/unknown-9.png)
@@ -126,7 +126,7 @@ In terminal:
       1. partition number: keep blank for default
       2. first sector: keep blank for default
       3. last sector: `+200M` to create a 200MB partition that will be named later on OPENCORE
-      4. Hex code or GUID: `0700` for Microsoft basic data partition type
+      4. Hex code or GUID: `EFI` system partition type
       ![](../images/installer-guide/linux-install-md/unknown-15.png)
    5. send `n`
       1. partition number: keep blank for default


### PR DESCRIPTION
This does not seem to bother anyone or to cause any harm to boot but...

the correct hexcode for ESP (aka EFI System Partition) is EF00 and not 0700 for microsoft data partition type