### PR TITLE
Add information about i3 5005U iGPU

### DIFF
--- a/config-laptop.plist/broadwell.md
+++ b/config-laptop.plist/broadwell.md
@@ -144,7 +144,7 @@ Generally follow these steps when setting up your iGPU properties. Follow the co
 
 #### Configuration Notes
 
-* For HD 5600 you need `device-id` faked to `26160000`:
+* For HD 5600 you need `device-id` faked to `26160000`. Some CPUs with HD 5500 such as i3 5005U may also require this to avoid getting stuck at `Scheduler Throttle Cap = 100ms`:
 
 | Key | Type | Value |
 | :--- | :--- | :--- |


### PR DESCRIPTION
I had to do this to get Monterey to boot on an HP Notebook 15-ac111tu (i3 5005U), it was getting stuck on `[IGPU] Scheduler Throttle Cap`. I found this from a post on OSXLatitude https://osxlatitude.com/forums/topic/12749-dell-inspiron-15-3558-no-success-trying-to-install-catalina/page/3/ which pointed to an old Clover config file.


So I checked what `device-id` it was spoofing to and it turned out to be the same one used here for HD 5600. After using `device-id`: `26160000` I can boot Monterey with working graphics acceleration on this laptop.


