### PR TITLE
Make users aware of linux-apfs-rw

### DIFF
--- a/installer-guide/README.md
+++ b/installer-guide/README.md
@@ -11,8 +11,8 @@ Requirements:
 Offline installers have a complete copy of macOS, while online installers are only a recovery image (~500MB) which then download macOS from Apple servers once booted.
 
 * Offline
-  * Can only be made in macOS
-  * Windows/Linux do not have the APFS/HFS drivers needed to assemble a full installer
+  * Can only be made in macOS or possibly Linux (with ![linux-apfs-rw](https://github.com/linux-apfs/linux-apfs-rw). Note that this Linux driver is considered unstable, and thus its usage is possible, but not recommendeded and will not be covered in this guide.)
+  * Windows does not have the APFS/HFS drivers needed to assemble a full installer
 * Online
   * Can be made in macOS/Linux/Windows
   * Requires a working internet connection via a macOS supported network adapter on the target machine

--- a/installer-guide/README.md
+++ b/installer-guide/README.md
@@ -11,7 +11,7 @@ Requirements:
 Offline installers have a complete copy of macOS, while online installers are only a recovery image (~500MB) which then download macOS from Apple servers once booted.
 
 * Offline
-  * Can only be made in macOS or possibly Linux (with ![linux-apfs-rw](https://github.com/linux-apfs/linux-apfs-rw). Note that this Linux driver is considered unstable, and thus its usage is possible, but not recommendeded and will not be covered in this guide.)
+  * Can only be made in macOS or possibly Linux (with [linux-apfs-rw](https://github.com/linux-apfs/linux-apfs-rw). Note that this Linux driver is considered unstable, and thus its usage is possible, but not recommendeded and will not be covered in this guide.)
   * Windows does not have the APFS/HFS drivers needed to assemble a full installer
 * Online
   * Can be made in macOS/Linux/Windows


### PR DESCRIPTION
The guide currently says it is not possible to create an offline installer with Linux. However, I have found an experimental APFS driver that works, [linux-apfs-rw](https://github.com/linux-apfs/linux-apfs-rw). I have used it to create a working installer in the past, and, despite its warnings, have accessed macOS installs with no corruption.