### PR TITLE
Add more Chromebook specific items+ random IceLake s0ix fix

### DIFF
--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -99,7 +99,7 @@ Settings relating to boot.efi patching and firmware fixes, for us, we need to ch
 
 | Quirk | Enabled | Comment |
 | :--- | :--- | :--- |
-| DevirtualiseMmio | YES |
+| DevirtualiseMmio | YES | **Do not enable on Chromebooks.**|
 | EnableWriteUnprotector | NO |
 | ProtectMemoryRegions| YES | Only for Chromebooks, leave disabled otherwise. |
 | ProtectUefiServices | YES |

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -163,6 +163,7 @@ Generally follow these steps when setting up your iGPU properties. Follow the co
 | AAPL,ig-platform-id | Port Count | Comment |
 | ------------------- | ---------- | ------- |
 | **`0000528A`** | 6 | Recommended G4/G7 value |
+|**`0200518A`** | 6 | Use if you encounter display issues after waking from sleep. |
 
 #### Configuration Notes
 

--- a/ktext.md
+++ b/ktext.md
@@ -382,8 +382,7 @@ However ProperTree will handle this for you, so you need not concern yourself
 * [RestrictEvents](https://github.com/acidanthera/RestrictEvents)
   * Patch various functions of macOS, see [the README](https://github.com/acidanthera/RestrictEvents#boot-arguments) for more info
 * [EmeraldSDHC](https://github.com/acidanthera/EmeraldSDHC)
-  * macOS kernel extension for eMMC support. Currently only supports eMMC/MMC cards at up to HS200 speeds.  This driver is currently a work in progress and may experience poor performance or be nonfunctional on some devices. SD cards are currently not supported at this time.
-
+  * macOS kernel extension for eMMC drive support. Driver is currently in a work in progress and may not work across all systems.
 ::: details Legacy SATA Kexts
 
 * [AppleIntelPIIXATA.kext](https://github.com/dortania/OpenCore-Legacy-Patcher/blob/d20d9975c144728da7ae2543d65422f53dabaa2d/payloads/Kexts/Misc/AppleIntelPIIXATA-v1.0.0.zip)

--- a/ktext.md
+++ b/ktext.md
@@ -414,6 +414,8 @@ Most laptop keyboards are PS2! You will want to grab VoodooPS2 even if you have 
 * [RehabMan's VoodooPS2](https://bitbucket.org/RehabMan/os-x-voodoo-ps2-controller/downloads/)
   * For older systems with PS2 keyboards, mice, and trackpads, or when you don't want to use VoodooInput
   * Supports macOS 10.6+
+* [ChromebookPS2](https://github.com/meghan06/ChromebookPS2)
+   * For Chromebooks only. Remaps the top row keys to their intended purpose.
 
 #### SMBus Trackpads
 

--- a/troubleshooting/extended/post-issues.md
+++ b/troubleshooting/extended/post-issues.md
@@ -346,3 +346,37 @@ For machines with HDMI 2.0 capable ports with resolution issues, verify the foll
   * `-cdfon`
 
 For all other troubleshooting, please reference [WhateverGreen's Intel docs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md)
+
+
+## Ice Lake Sleep/Wake issues
+
+For Ice Lake machines that encounter problems after waking from sleep. 
+
+Before proceeding, we need to determine if your machine has AOAC enabled. AOAC stands for "Always On Always Connected", AKA s0ix sleep.
+* Open MaciASL
+* Click on "File > New From ACPI" and select FACP.aml
+* Search for `Low Power S0 Idle`. If the value is `= 1`, it is an AOAC machine. 
+    e.g
+
+      Low Power S0 Idle (V5) : 1
+
+Possible Solutions:
+
+1. Disabling s0ix from BIOS:
+Look for anything with SO Low Power or s0ix in your firmware settings and disable them.  
+
+2. Patching macOS via ACPI hotpatches:
+**WARNING:** These ACPI patches are known to be quite unstable and even uneffective at times, proceed at your own risk.
+See [here](https://github.com/5T33Z0/OC-Little-Translated/tree/main/04_Fixing_Sleep_and_Wake_Issues/Fixing_AOAC_Machines)
+
+3. Re-enabling S3 and disabling s0ix:
+**Note:** This only applies to **some** Dell laptops. If your DSDT has `_S3` in it, the following fixes will work.
+
+1. Grab the SSDT and ACPI rename from [meghan6's repo](https://github.com/meghan06/DellAOAC-Hotpatch), 
+2. Verify the ACPI pathing is correct for your device
+3. Place SSDT-S3.aml into your ACPI folder
+4. Paste the ACPI rename into ACPI -> Patch
+5. Disable hibernation within macOS:
+   `sudo pmset -a hibernatemode 0`
+
+


### PR DESCRIPTION
This PR adds the following:
- Chromebook specific fixes 
     - `DevirtualizeMimo` breaks NVRAM on CometLake Chromebooks. A note has been added to warn Chromebook hacks to keep that flag disabled.
- An s0ix fix for certain IceLake machines
