### PR TITLE
Add Sonoma recovery Python links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ actionLink: prerequisites.md
 
 meta:
 - name: description
-  content: Current supported version 0.9.1
+  content: Current supported version 0.9.6
 ---
 
 # What is OpenCore and who is this guide for

--- a/installer-guide/linux-install.md
+++ b/installer-guide/linux-install.md
@@ -56,9 +56,12 @@ python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 ./macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 ./macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 From here, run one of those commands in terminal and once finished you'll get an output similar to this:

--- a/installer-guide/mac-install-recovery.md
+++ b/installer-guide/mac-install-recovery.md
@@ -44,9 +44,12 @@ python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 ./macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 ./macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.

--- a/installer-guide/windows-install.md
+++ b/installer-guide/windows-install.md
@@ -55,9 +55,12 @@ python3 macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.


### PR DESCRIPTION
Considering add macOS Sonoma's macrecovery py links to the OpenCore Install Guide.