### PR TITLE
Add Sonoma macrecovery commands to the install guide

### DIFF
--- a/installer-guide/linux-install.md
+++ b/installer-guide/linux-install.md
@@ -56,9 +56,12 @@ python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 ./macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 ./macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 ./macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 From here, run one of those commands in terminal and once finished you'll get an output similar to this:

--- a/installer-guide/mac-install-recovery.md
+++ b/installer-guide/mac-install-recovery.md
@@ -44,9 +44,12 @@ python3 ./macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 ./macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 ./macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 ./macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.

--- a/installer-guide/windows-install.md
+++ b/installer-guide/windows-install.md
@@ -55,9 +55,12 @@ python3 macrecovery.py -b Mac-42FD25EABCABB274 -m 00000000000000000 download
 # Monterey (12)
 python3 macrecovery.py -b Mac-FFE5EF870D7BA81A -m 00000000000000000 download
 
-# Latest version
-# ie. Ventura (13)
+# Ventura (13)
 python3 macrecovery.py -b Mac-4B682C642B45593E -m 00000000000000000 download
+
+# Latest version
+# ie. Sonoma (14)
+python3 macrecovery.py -b Mac-937A206F2EE63C01 -m 00000000000000000 download
 ```
 
 * **macOS 12 and above note**: As recent macOS versions introduce changes to the USB stack, it is highly advisable that you map your USB ports (with USBToolBox) before installing macOS.


### PR DESCRIPTION
This PR adds macrecovery commands for macOS 14 Sonoma to the install guide pages for macOS, Linux and Windows. I used the `Mac-937A206F2EE63C01` BoardID which corresponds to MacBookPro15,1 (15-inch Mid 2018).

This change would affect the following locations:
1. https://dortania.github.io/OpenCore-Install-Guide/installer-guide/windows-install.html#downloading-macos
2. https://dortania.github.io/OpenCore-Install-Guide/installer-guide/linux-install.html#downloading-macos
3. https://dortania.github.io/OpenCore-Install-Guide/installer-guide/mac-install-recovery.html

Preview of proposed changes:
<img width="707" alt="image" src="https://github.com/dortania/OpenCore-Install-Guide/assets/10524728/55908e48-5fda-4395-bf2f-74ba3ad07982">