### PR TITLE
Improve Penryn instructions in the Booter > Quirks section.

### DIFF
--- a/config.plist/penryn.md
+++ b/config.plist/penryn.md
@@ -97,6 +97,7 @@ Settings relating to boot.efi patching and firmware fixes, depending where your 
 | Quirk | Enabled | Comment |
 | :--- | :--- | :--- |
 | RebuildAppleMemoryMap | Yes | This is required to boot OS X 10.4 through 10.6 |
+| EnableWriteUnprotector | No | Must be disabled IF using RebuildAppleMemoryMap |
 
 :::
 ::: details More in-depth Info


### PR DESCRIPTION
Whenever using RebuildAppleMemoryMap, EnableWriteUnprotector needs to be disabled as well since those two quirks commonly conflict with each other. This commit brings that upfront when following the Penryn portion of the guide.

This is just a simple change for now and I might make some big commit updating everything in this guide wherever possible.