### PR TITLE
Add a notice for SecureBootModel on Sonoma and Kaby Lake SMbios fixes

### DIFF
--- a/config-laptop.plist/coffee-lake-plus.md
+++ b/config-laptop.plist/coffee-lake-plus.md
@@ -464,6 +464,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -436,6 +436,7 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 
 **Note for macOS Sonoma 14 and above**: 
 Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info

--- a/config-laptop.plist/coffee-lake.md
+++ b/config-laptop.plist/coffee-lake.md
@@ -434,6 +434,8 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
 :::
 
 ::: details More in-depth Info

--- a/config-laptop.plist/icelake.md
+++ b/config-laptop.plist/icelake.md
@@ -426,6 +426,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info

--- a/config-laptop.plist/kaby-lake.md
+++ b/config-laptop.plist/kaby-lake.md
@@ -513,6 +513,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info
@@ -657,6 +660,15 @@ For this Kaby Lake example, we'll chose the MacBookPro14,1 SMBIOS - this is done
 | MacBookPro14,2 | Dual Core 15W(High End) | iGPU: Iris Plus 650 | 13" | Yes |
 | MacBookPro14,3 | Quad Core 45W | iGPU: HD 630 + dGPU: Radeon Pro 555X/560X | 15" | Yes |
 | iMac18,1 | NUC Systems | iGPU: Iris Plus 640 |  N/A | No |
+
+**Note for macOS 14 Sonoma and above**: Since Kaby Lake and Amber Lake are still natively supported in Sonoma and above you can still run it but you'll need to use a Coffee Lake SMBIOS that is closest to your configuration from the table below.
+
+| SMBIOS | CPU Type | GPU Type | Display Size | Touch ID |
+| :--- | :--- | :--- | :--- | :--- |
+| MacBookPro15,1 | Hexa Core 45W | iGPU: UHD 630 + dGPU: Radeon Pro 555X/560X | 15" | Yes |
+| MacBookPro15,2 | Quad Core 15W | iGPU: Iris 655 | 13" | Yes |
+| MacBookPro15,3 | Hexa Core 45W | iGPU: UHD 630 + dGPU: Vega 16/20 | 15" | Yes |
+| Macmini8,1 | NUC Systems | HD 6000/Iris Pro 6200 |  N/A | No |
 
 Run GenSMBIOS, pick option 1 for downloading MacSerial and Option 3 for selecting out SMBIOS.  This will give us an output similar to the following:
 

--- a/config.plist/coffee-lake.md
+++ b/config.plist/coffee-lake.md
@@ -402,6 +402,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info

--- a/config.plist/comet-lake.md
+++ b/config.plist/comet-lake.md
@@ -435,6 +435,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info

--- a/config.plist/kaby-lake.md
+++ b/config.plist/kaby-lake.md
@@ -377,6 +377,9 @@ Security is pretty self-explanatory, **do not skip**. We'll be changing the foll
 | SecureBootModel | Default | Leave this as `Default` for OpenCore to automatically set the correct value corresponding to your SMBIOS. The next page goes into more detail about this setting. |
 | Vault | Optional | This is a word, it is not optional to omit this setting. You will regret it if you don't set it to Optional, note that it is case-sensitive |
 
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip (of which we don't physically have) during the second install phase (i.e after the reboot into macOS installer from the local disk), you'll need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 :::
 
 ::: details More in-depth Info
@@ -535,6 +538,12 @@ For this Kaby Lake example, we'll chose the iMac18,1 SMBIOS - this is done inten
 | :--- | :--- |
 | iMac18,1 | Used for computers utilizing the iGPU for displaying |
 | iMac18,3 | Used for computers using a dGPU for displaying, and an iGPU for computing tasks only |
+
+**Note for macOS 14 Sonoma and above**: Since Kaby Lake is still natively supported in Sonoma and above you can still run it but you'll need to use a Coffee Lake SMBIOS that is present in the table below.
+
+| SMBIOS | Hardware |
+| :--- | :--- |
+| iMac19,1 | For Mojave and newer |
 
 Run GenSMBIOS, pick option 1 for downloading MacSerial and Option 3 for selecting out SMBIOS.  This will give us an output similar to the following:
 

--- a/config.plist/security.md
+++ b/config.plist/security.md
@@ -10,6 +10,10 @@ OpenCore by default has [Apple Secure Boot](https://dortania.github.io/OpenCore-
 This enables security features such as the verification of macOS' `boot.efi`, with the side effect of restricting which macOS versions OpenCore will boot.
 
 * Big Sur and Above (11.0+): The recommended value is `Default`.
+  
+**Note for macOS Sonoma 14 and above**: 
+Due to macOS polling for more information from the Mac's T2 chip of which we don't have you need to set SecureBootModel to `Disabled` for the duration of the install, after successfully booting into the desktop you can set SecureBootModel back to `Default`, this also applies to updating the OS to a minor release (i.e 14.6 -> 14.7) or a major release (i.e 14.7 -> 15.0)
+
 * High Sierra-Catalina (10.13-10.15):
   * If your model is not listed below, set to `Disabled`.
   * If running NVIDIA Web Drivers, set to `Disabled`.


### PR DESCRIPTION
Added the notice in all relevant CPU config.plist sections for desktop and laptop  that is natively capable of running sonoma + the page about SecureBoot about the need to set SecureBootModel to disable to install the OS succesfully. Also since Kaby lake is still natively supported on sonoma and above, added a notice to use a coffee lake SMbios with an appropriate SMbios table relevant to the desktop and laptop section

kthxbye :)