### PR TITLE
Fix buildconfig for release kernel

### DIFF
--- a/troubleshooting/kernel-debugging.md
+++ b/troubleshooting/kernel-debugging.md
@@ -380,4 +380,4 @@ sysctl kern.osbuildconfig
  kern.osbuildconfig: release
 ```
 
-And as we can see, we're successfully booting a KASAN kernel.
+And as we can see, we're successfully booting a release kernel.


### PR DESCRIPTION
After the KDK is uninstalled, a release kernel should be booted & displayed (the command output is correct).