### PR TITLE
update Ethernet kext links with newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ actionLink: prerequisites.md
 
 meta:
 - name: description
-  content: Current supported version 1.0.5
+  content: Current supported version 1.0.6
 ---
 
 # What is OpenCore and who is this guide for

--- a/ktext.md
+++ b/ktext.md
@@ -154,10 +154,11 @@ For those who plan to boot 10.7 and older may want to opt for these kexts instea
 
 Here we're going to assume you know what ethernet card your system has, reminder that product spec pages will most likely list the type of network card.
 
-* [IntelMausi](https://github.com/Mieze/IntelMausiEthernet/releases)
+* [IntelMausi](https://github.com/acidanthera/IntelMausi/releases)
   * Required for the majority of Intel NICs, chipsets that are based off of I211 will need the SmallTreeIntel82576 kext
   * Intel's 82578, 82579, I217, I218 and I219 NICs are officially supported
-  * Requires OS X 10.13 or newer, 10.6-10.12 users can use [acidanthera's](https://github.com/acidanthera/IntelMausi/releases) version instead for older OSes (use IntelSnowMausi for 10.6-10.8)
+  * Requires OS X 10.9 or newer, 10.6-10.8 users can use IntelSnowMausi instead for older OSes
+  * VT-d users and Rocket Lake+ boards running I219 NICs can use [Mieze's fork](https://github.com/Mieze/IntelMausiEthernet/releases)
 * [AppleIGB](https://github.com/donatengit/AppleIGB/releases)
   * Required for I211 NICs running on macOS Monterey and above
   * Might have instability issues on some NICs, recommended to stay on Big Sur and use SmallTree
@@ -175,7 +176,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
-* [RTL812xLucy](https://github.com/Mieze/RTL812xLucy/releases)
+* [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.

--- a/ktext.md
+++ b/ktext.md
@@ -176,10 +176,10 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
-* [RTL812xLucy](https://www.insanelymac.com/forum/topic/362326-rtl812xlucy-for-the-realtek-rtl812x-family/)
+* [RTL812xLucy](https://github.com/Mieze/RTL812xLucy/releases)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer
-  * **NOTE:** This kext is currently in beta, use [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases) if experiencing issues
+  * **NOTE:** If the kext doesn't work properly, try using [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases) instead.
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.
   * For macOS 13 and above, the kext supporting I225-V NICs was dropped and replaced with a DriverKit DEXT instead. This DEXT requires working VT-d, so we recommended reusing the older kext: [AppleIntelI210Ethernet](extra-files/AppleIntelI210Ethernet.kext.zip)
     * Monterey and older need not concern

--- a/ktext.md
+++ b/ktext.md
@@ -176,9 +176,10 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
-* [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases)
+* [RTL812xLucy](https://www.insanelymac.com/forum/topic/362326-rtl812xlucy-for-the-realtek-rtl812x-family/)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer
+  * **NOTE:** This kext is currently in beta, use [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases) if experiencing issues
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.
   * For macOS 13 and above, the kext supporting I225-V NICs was dropped and replaced with a DriverKit DEXT instead. This DEXT requires working VT-d, so we recommended reusing the older kext: [AppleIntelI210Ethernet](extra-files/AppleIntelI210Ethernet.kext.zip)
     * Monterey and older need not concern

--- a/ktext.md
+++ b/ktext.md
@@ -154,10 +154,10 @@ For those who plan to boot 10.7 and older may want to opt for these kexts instea
 
 Here we're going to assume you know what ethernet card your system has, reminder that product spec pages will most likely list the type of network card.
 
-* [IntelMausi](https://github.com/acidanthera/IntelMausi/releases)
+* [IntelMausi](https://github.com/Mieze/IntelMausiEthernet/releases)
   * Required for the majority of Intel NICs, chipsets that are based off of I211 will need the SmallTreeIntel82576 kext
   * Intel's 82578, 82579, I217, I218 and I219 NICs are officially supported
-  * Requires OS X 10.9 or newer, 10.6-10.8 users can use IntelSnowMausi instead for older OSes
+  * Requires OS X 10.13 or newer, 10.6-10.12 users can use [acidanthera's](https://github.com/acidanthera/IntelMausi/releases) version instead for older OSes (use IntelSnowMausi for 10.6-10.8)
 * [AppleIGB](https://github.com/donatengit/AppleIGB/releases)
   * Required for I211 NICs running on macOS Monterey and above
   * Might have instability issues on some NICs, recommended to stay on Big Sur and use SmallTree

--- a/ktext.md
+++ b/ktext.md
@@ -175,7 +175,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * For Realtek's Gigabit Ethernet
   * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
-* [LucyRTL8125Ethernet](https://www.insanelymac.com/forum/files/file/1004-lucyrtl8125ethernet/)
+* [RTL812xLucy](https://github.com/Mieze/RTL812xLucy/releases)
   * For Realtek's 2.5Gb Ethernet
   * Requires macOS 10.15 or newer
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.

--- a/ktext.md
+++ b/ktext.md
@@ -177,12 +177,13 @@ Here we're going to assume you know what ethernet card your system has, reminder
   * Requires OS X 10.8 and up for versions v2.2.0 and below, macOS 10.12 and up for version v2.2.2, macOS 10.14 and up for versions v2.3.0 and up
   * **NOTE:** Sometimes the latest version of the kext might not work properly with your Ethernet. If you see this issue, try older versions.
 * [RTL812xLucy](https://github.com/Mieze/RTL812xLucy/releases)
-  * For Realtek's 2.5Gb Ethernet
+  * For Realtek's 2.5 and 5Gb Ethernet NICs
   * Requires macOS 10.15 or newer
-  * **NOTE:** If the kext doesn't work properly, try using [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases) instead.
+  * **NOTE:** If the kext doesn't work properly, try using [LucyRTL8125Ethernet](https://github.com/Mieze/LucyRTL8125Ethernet/releases) instead (RTL8125B only).
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.
   * For macOS 13 and above, the kext supporting I225-V NICs was dropped and replaced with a DriverKit DEXT instead. This DEXT requires working VT-d, so we recommended reusing the older kext: [AppleIntelI210Ethernet](extra-files/AppleIntelI210Ethernet.kext.zip)
     * Monterey and older need not concern
+	* I226-V or non VT-d users can alternatively use [AppleIGC](https://github.com/SongXiaoXi/AppleIGC/releases) instead
   * Requires macOS 10.15 or newer
 * For Intel's I350 NICs, patches are mentioned in the HEDT [Sandy and Ivy Bridge-E DeviceProperties](config-HEDT/ivy-bridge-e.md#deviceproperties) section. No kext is required.
   * Requires OS X 10.10 or newer

--- a/ktext.md
+++ b/ktext.md
@@ -183,7 +183,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.
   * For macOS 13 and above, the kext supporting I225-V NICs was dropped and replaced with a DriverKit DEXT instead. This DEXT requires working VT-d, so we recommended reusing the older kext: [AppleIntelI210Ethernet](extra-files/AppleIntelI210Ethernet.kext.zip)
     * Monterey and older need not concern
-	* I226-V or non VT-d users can alternatively use [AppleIGC](https://github.com/SongXiaoXi/AppleIGC/releases) instead
+	  * I226-V or non VT-d users can alternatively use [AppleIGC](https://github.com/SongXiaoXi/AppleIGC/releases) instead
   * Requires macOS 10.15 or newer
 * For Intel's I350 NICs, patches are mentioned in the HEDT [Sandy and Ivy Bridge-E DeviceProperties](config-HEDT/ivy-bridge-e.md#deviceproperties) section. No kext is required.
   * Requires OS X 10.10 or newer

--- a/ktext.md
+++ b/ktext.md
@@ -183,7 +183,7 @@ Here we're going to assume you know what ethernet card your system has, reminder
 * For Intel's I225-V NICs, patches are mentioned in the desktop [Comet Lake DeviceProperties](config.plist/comet-lake.md#deviceproperties) section.
   * For macOS 13 and above, the kext supporting I225-V NICs was dropped and replaced with a DriverKit DEXT instead. This DEXT requires working VT-d, so we recommended reusing the older kext: [AppleIntelI210Ethernet](extra-files/AppleIntelI210Ethernet.kext.zip)
     * Monterey and older need not concern
-	  * I226-V or non VT-d users can alternatively use [AppleIGC](https://github.com/SongXiaoXi/AppleIGC/releases) instead
+    * I226-V or non VT-d users can alternatively use [AppleIGC](https://github.com/SongXiaoXi/AppleIGC/releases) instead
   * Requires macOS 10.15 or newer
 * For Intel's I350 NICs, patches are mentioned in the HEDT [Sandy and Ivy Bridge-E DeviceProperties](config-HEDT/ivy-bridge-e.md#deviceproperties) section. No kext is required.
   * Requires OS X 10.10 or newer


### PR DESCRIPTION
- added Mieze's IntelMausiEthernet variant
- added RTL812xLucy with LucyRTL8125Ethernet as alternative