### PR TITLE
fix broadwell page

### DIFF
--- a/config-laptop.plist/broadwell.md
+++ b/config-laptop.plist/broadwell.md
@@ -4,7 +4,6 @@
 | :--- | :--- |
 | Initial macOS Support | OS X 10.10, Yosemite |
 | Last Supported OS | macOS 12 Monterey |
-| Note | For Ventura information, see [macOS 13 Ventura](../extras/ventura.md#dropped-cpu-support) |
 
 ## Starting Point
 


### PR DESCRIPTION
broadwell cpu still has support in ventura as it has avx2 instuctions