### PR TITLE
fix haswell page

### DIFF
--- a/config-laptop.plist/haswell.md
+++ b/config-laptop.plist/haswell.md
@@ -4,7 +4,6 @@
 | :--- | :--- |
 | Initial macOS Support | OS X 10.8, Mountain Lion |
 | Last Supported OS | macOS 12 Monterey |
-| Note | For Ventura information, see [macOS 13 Ventura](../extras/ventura.md#dropped-cpu-support) |
 
 ## Starting Point
 


### PR DESCRIPTION
haswell cpu still has support in ventura as it has avx2 instuctions